### PR TITLE
Move to using __construct, adhere to PEAR CS and strip trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ install:
   - pear install package.xml
 php:
   - 5.4
+  - 5.6
+  - 7.2
 sudo: false
 script: phpunit tests/

--- a/Cache.php
+++ b/Cache.php
@@ -22,100 +22,100 @@ require_once 'PEAR.php';
 require_once 'Cache/Error.php';
 
 /**
-* Cache is a base class for cache implementations.
-*
-* The pear cache module is a generic data cache which can be used to
-* cache script runs. The idea behind the cache is quite simple. If you have
-* the same input parameters for whatever tasks/algorithm you use you'll
-* usually get the same output. So why not caching templates, functions calls,
-* graphic generation etc. Caching certain actions e.g. XSLT tranformations
-* saves you lots of time.
-*
-* The design of the cache reminds of PHPLibs session implementation. A
-* (PHPLib: session) controller uses storage container (PHPLib: ct_*.inc) to save
-* certain data (PHPLib: session data). In contrast to the session stuff it's up to
-* you to generate an ID for the data to cache. If you're using the output cache
-* you might use the script name as a seed for cache::generateID(), if your using the
-* function cache you'd use an array with all function parameters.
-*
-* Usage example of the generic data cache:
-*
-* require_once('Cache.php');
-*
-* $cache = new Cache('file', array('cache_dir' => 'cache/') );
-* $id = $cache->generateID('testentry');
-*
-* if ($data = $cache->get($id)) {
-*    print "Cache hit.<br>Data: $data";
-*
-* } else {
-*   $data = 'data of any kind';
-*   $cache->save($id, $data);
-*   print 'Cache miss.<br>';
-* }
-*
-* WARNING: No File/DB-Table-Row locking is implemented yet,
-*          it's possible, that you get corrupted data-entries under
-*          bad circumstances  (especially with the file container)
-*
-* @author   Ulf Wendel <ulf.wendel@phpdoc.de>
-* @version  $Id$
-* @package  Cache
-* @access   public
-*/
+ * Cache is a base class for cache implementations.
+ *
+ * The pear cache module is a generic data cache which can be used to
+ * cache script runs. The idea behind the cache is quite simple. If you have
+ * the same input parameters for whatever tasks/algorithm you use you'll
+ * usually get the same output. So why not caching templates, functions calls,
+ * graphic generation etc. Caching certain actions e.g. XSLT tranformations
+ * saves you lots of time.
+ *
+ * The design of the cache reminds of PHPLibs session implementation. A
+ * (PHPLib: session) controller uses storage container (PHPLib: ct_*.inc) to save
+ * certain data (PHPLib: session data). In contrast to the session stuff it's up to
+ * you to generate an ID for the data to cache. If you're using the output cache
+ * you might use the script name as a seed for cache::generateID(), if your using the
+ * function cache you'd use an array with all function parameters.
+ *
+ * Usage example of the generic data cache:
+ *
+ * require_once('Cache.php');
+ *
+ * $cache = new Cache('file', array('cache_dir' => 'cache/') );
+ * $id = $cache->generateID('testentry');
+ *
+ * if ($data = $cache->get($id)) {
+ *    print "Cache hit.<br>Data: $data";
+ *
+ * } else {
+ *   $data = 'data of any kind';
+ *   $cache->save($id, $data);
+ *   print 'Cache miss.<br>';
+ * }
+ *
+ * WARNING: No File/DB-Table-Row locking is implemented yet,
+ *          it's possible, that you get corrupted data-entries under
+ *          bad circumstances  (especially with the file container)
+ *
+ * @author  Ulf Wendel <ulf.wendel@phpdoc.de>
+ * @version $Id$
+ * @package Cache
+ * @access  public
+ */
 class Cache extends PEAR
 {
 
     /**
-    * Enables / disables caching.
-    *
-    * TODO: Add explanation what this is good for.
-    *
-    * @var      boolean
-    * @access   private
-    */
+     * Enables / disables caching.
+     *
+     * TODO: Add explanation what this is good for.
+     *
+     * @var    boolean
+     * @access private
+     */
     var $caching = true;
 
     /**
-    * Garbage collection: probability in seconds
-    *
-    * If set to a value above 0 a garbage collection will
-    * flush all cache entries older than the specified number
-    * of seconds.
-    *
-    * @var      integer
-    * @see      $gc_probability, $gc_maxlifetime
-    * @access   public
-    */
+     * Garbage collection: probability in seconds
+     *
+     * If set to a value above 0 a garbage collection will
+     * flush all cache entries older than the specified number
+     * of seconds.
+     *
+     * @var    integer
+     * @see    $gc_probability, $gc_maxlifetime
+     * @access public
+     */
     var $gc_time  = 1;
 
     /**
-    * Garbage collection: probability in percent
-    *
-    * TODO: Add an explanation.
-    *
-    * @var      integer     0 => never
-    * @see      $gc_time, $gc_maxlifetime
-    * @access   public
-    */
+     * Garbage collection: probability in percent
+     *
+     * TODO: Add an explanation.
+     *
+     * @var    integer     0 => never
+     * @see    $gc_time, $gc_maxlifetime
+     * @access public
+     */
     var $gc_probability = 1;
 
     /**
-    * Garbage collection: delete all entries not use for n seconds.
-    *
-    * Default is one day, 60 * 60 * 24 = 86400 seconds.
-    *
-    * @var  integer
-    * @see  $gc_probability, $gc_time
-    */
+     * Garbage collection: delete all entries not use for n seconds.
+     *
+     * Default is one day, 60 * 60 * 24 = 86400 seconds.
+     *
+     * @var integer
+     * @see $gc_probability, $gc_time
+     */
     var $gc_maxlifetime = 86400;
 
     /**
-    * Storage container if sucess in load it
-    * and a Cache_Error if not
-    *
-    * @var  Cache_Container|Cache_Error $container
-    */
+     * Storage container if sucess in load it
+     * and a Cache_Error if not
+     *
+     * @var Cache_Container|Cache_Error $container
+     */
     var $container;
 
     //
@@ -123,15 +123,15 @@ class Cache extends PEAR
     //
 
     /**
-    * this Constructor set the Container Property as 
-    * a Cache_Container|Cache_Error Object.
-    * it Depends if a container is sucessfully  load
-    * if not, a Cache_Error is set
-    *
-    * @param    string  Name of container class
-    * @param    array   Array with container class options
-    */
-    function Cache($container, $container_options = null)
+     * this Constructor set the Container Property as
+     * a Cache_Container|Cache_Error Object.
+     * it Depends if a container is sucessfully  load
+     * if not, a Cache_Error is set
+     *
+     * @param string  Name of container class
+     * @param array   Array with container class options
+     */
+    function __construct($container, $container_options = null)
     {
         if (!is_array($container_options) && !is_null($container_options)) {
             $this->container = new Cache_Error(
@@ -163,8 +163,8 @@ class Cache extends PEAR
     /**
      * Returns the current caching state.
      *
-     * @return  boolean     The current caching state.
-     * @access  public
+     * @return boolean     The current caching state.
+     * @access public
      */
     function getCaching()
     {
@@ -174,8 +174,8 @@ class Cache extends PEAR
     /**
      * Enables or disables caching.
      *
-     * @param   boolean     The new caching state.
-     * @access  public
+     * @param  boolean     The new caching state.
+     * @access public
      */
     function setCaching($state)
     {
@@ -183,13 +183,13 @@ class Cache extends PEAR
     }
 
     /**
-    * Returns the requested dataset it if exists and is not expired
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   mixed   cached data or null on failure
-    * @access   public
-    */
+     * Returns the requested dataset it if exists and is not expired
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return mixed   cached data or null on failure
+     * @access public
+     */
     function get($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -203,36 +203,36 @@ class Cache extends PEAR
     } // end func get
 
     /**
-    * Stores the given data in the cache.
-    *
-    * @param    string  dataset ID used as cache identifier
-    * @param    mixed   data to cache
-    * @param    integer lifetime of the cached data in seconds - 0 for endless
-    * @param    string  cache group
-    * @return   boolean
-    * @access   public
-    */
+     * Stores the given data in the cache.
+     *
+     * @param  string  dataset ID used as cache identifier
+     * @param  mixed   data to cache
+     * @param  integer lifetime of the cached data in seconds - 0 for endless
+     * @param  string  cache group
+     * @return boolean
+     * @access public
+     */
     function save($id, $data, $expires = 0, $group = 'default')
     {
         if (!$this->caching) {
             return true;
         }
-        return $this->extSave($id, $data, '',$expires, $group);
+        return $this->extSave($id, $data, '', $expires, $group);
     } // end func save
 
     /**
-    * Stores a dataset with additional userdefined data.
-    *
-    * @param    string  dataset ID
-    * @param    mixed   data to store
-    * @param    string  additional userdefined data
-    * @param    mixed   userdefined expire date
-    * @param    string  cache group
-    * @return   boolean
-    * @throws   Cache_Error
-    * @access   public
-    * @see      getUserdata()
-    */
+     * Stores a dataset with additional userdefined data.
+     *
+     * @param  string  dataset ID
+     * @param  mixed   data to store
+     * @param  string  additional userdefined data
+     * @param  mixed   userdefined expire date
+     * @param  string  cache group
+     * @return boolean
+     * @throws Cache_Error
+     * @access public
+     * @see    getUserdata()
+     */
     function extSave($id, $cachedata, $userdata, $expires = 0, $group = 'default')
     {
         if (!$this->caching) {
@@ -242,13 +242,13 @@ class Cache extends PEAR
     } // end func extSave
 
     /**
-    * Loads the given ID from the cache.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   mixed   cached data or null on failure
-    * @access   public
-    */
+     * Loads the given ID from the cache.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return mixed   cached data or null on failure
+     * @access public
+     */
     function load($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -258,14 +258,14 @@ class Cache extends PEAR
     } // end func load
 
     /**
-    * Returns the userdata field of a cached data set.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   string  userdata
-    * @access   public
-    * @see      extSave()
-    */
+     * Returns the userdata field of a cached data set.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return string  userdata
+     * @access public
+     * @see    extSave()
+     */
     function getUserdata($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -275,13 +275,13 @@ class Cache extends PEAR
     } // end func getUserdata
 
     /**
-    * Removes the specified dataset from the cache.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    * @access   public
-    */
+     * Removes the specified dataset from the cache.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return boolean
+     * @access public
+     */
     function remove($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -291,11 +291,11 @@ class Cache extends PEAR
     } // end func remove
 
     /**
-    * Flushes the cache - removes all data from it
-    *
-    * @param    string  cache group, if empty all groups will be flashed
-    * @return   integer number of removed datasets
-    */
+     * Flushes the cache - removes all data from it
+     *
+     * @param  string  cache group, if empty all groups will be flashed
+     * @return integer number of removed datasets
+     */
     function flush($group = 'default')
     {
         if (!$this->caching) {
@@ -305,15 +305,15 @@ class Cache extends PEAR
     } // end func flush
 
     /**
-    * Checks if a dataset exists.
-    *
-    * Note: this does not say that the cached data is not expired!
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    * @access   public
-    */
+     * Checks if a dataset exists.
+     *
+     * Note: this does not say that the cached data is not expired!
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return boolean
+     * @access public
+     */
     function isCached($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -323,19 +323,20 @@ class Cache extends PEAR
     } // end func isCached
 
     /**
-    * Checks if a dataset is expired
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @param    integer maximum age for the cached data in seconds - 0 for endless
-    *                   If the cached data is older but the given lifetime it will
-    *                   be removed from the cache. You don't have to provide this
-    *                   argument if you call isExpired(). Every dataset knows
-    *                   it's expire date and will be removed automatically. Use
-    *                   this only if you know what you're doing...
-    * @return   boolean
-    * @access   public
-    */
+     * Checks if a dataset is expired
+     *
+     * @param string  dataset ID
+     * @param string  cache group
+     * @param integer maximum age for the cached data in seconds - 0 for endless
+     *                   If the cached data is older but the given lifetime it will
+     *                   be removed from the cache. You don't have to provide this
+     *                   argument if you call isExpired(). Every dataset knows
+     *                   it's expire date and will be removed automatically. Use
+     *                   this only if you know what you're doing...
+     *
+     * @return boolean
+     * @access public
+     */
     function isExpired($id, $group = 'default', $max_age = 0)
     {
         if (!$this->caching) {
@@ -345,15 +346,16 @@ class Cache extends PEAR
     } // end func isExpired
 
     /**
-    * Generates a "unique" ID for the given value
-    *
-    * This is a quick but dirty hack to get a "unique" ID for a any kind of variable.
-    * ID clashes might occur from time to time although they are extreme unlikely!
-    *
-    * @param    mixed   variable to generate a ID for
-    * @return   string  "unique" ID
-    * @access   public
-    */
+     * Generates a "unique" ID for the given value
+     *
+     * This is a quick but dirty hack to get a "unique" ID for a any kind of variable.
+     * ID clashes might occur from time to time although they are extreme unlikely!
+     *
+     * @param  mixed $variable variable to generate a ID for
+     *
+     * @access public
+     * @return string  "unique" ID
+     */
     function generateID($variable)
     {
         // WARNING: ID clashes are possible although unlikely
@@ -361,11 +363,13 @@ class Cache extends PEAR
     }
 
     /**
-    * Calls the garbage collector of the storage object with a certain probability
-    *
-    * @param    boolean Force a garbage collection run?
-    * @see  $gc_probability, $gc_time
-    */
+     * Calls the garbage collector of the storage object with a certain probability
+     *
+     * @param boolean Force a garbage collection run?
+     * @see   $gc_probability, $gc_time
+     *
+     * @return null
+     */
     function garbageCollection($force = false)
     {
         static $last_run = 0;
@@ -375,7 +379,10 @@ class Cache extends PEAR
         }
 
         // time and probability based
-        if (($force) || ($last_run && $last_run < time() + $this->gc_time) || (rand(1, 100) < $this->gc_probability)) {
+        if (($force)
+            || ($last_run && $last_run < time() + $this->gc_time)
+            || (rand(1, 100) < $this->gc_probability)
+        ) {
             $this->container->garbageCollection($this->gc_maxlifetime);
             $last_run = time();
         }

--- a/Cache/Application.php
+++ b/Cache/Application.php
@@ -44,7 +44,7 @@ require_once 'Cache.php';
 //
 // $app =& new Cache_Application();
 // $app->register('foo');
-// $app->register('bar', $bar); 
+// $app->register('bar', $bar);
 //
 // $foo = 'Different data';
 //
@@ -53,7 +53,7 @@ require_once 'Cache.php';
 //
 // As with session_register(), the contents of the variable at the *end* of the
 // request is registered and not at the point of registration. Therefore in this
-// example, for the $foo variable, the string 'Different data' is stored and not 
+// example, for the $foo variable, the string 'Different data' is stored and not
 // 'Some data'. The exception to this rule is if you use the second argument to
 // register() as in the second call to it above. This will cause the data supplied
 // in the second argument to be stored and not the contents at the end of the request.
@@ -79,12 +79,12 @@ class Cache_Application extends Cache
     var $registered_vars;
 
     /**
-    * Constructor
-    *
-    * @param    string  Name of container class
-    * @param    array   Array with container class options
-    */
-    function Cache_Application($container = 'file', $container_options = array('cache_dir' => '/tmp/', 'filename_prefix' => 'cache_'), $id = 'application_var', $group = 'application_cache')
+     * Constructor
+     *
+     * @param string  Name of container class
+     * @param array   Array with container class options
+     */
+    function __construct($container = 'file', $container_options = array('cache_dir' => '/tmp/', 'filename_prefix' => 'cache_'), $id = 'application_var', $group = 'application_cache')
     {
         $this->id    = $id;
         $this->group = $group;
@@ -103,11 +103,11 @@ class Cache_Application extends Cache
     }
 
     /**
-    * Destructor
-    *
-    * Gets values of all registered variables and stores them. Then calls save() to
-    * write data away.
-    */
+     * Destructor
+     *
+     * Gets values of all registered variables and stores them. Then calls save() to
+     * write data away.
+     */
     function _Cache_Application()
     {
         // Get contents of all registered variables
@@ -123,13 +123,13 @@ class Cache_Application extends Cache
     }
 
     /**
-    * register()
-    *
-    * Registers a variable to be stored.
-    *
-    * @param    string  Name of variable to register
-    * @param    mixed   Optional data to store
-    */
+     * register()
+     *
+     * Registers a variable to be stored.
+     *
+     * @param string  Name of variable to register
+     * @param mixed   Optional data to store
+     */
     function register($varname, $data = null)
     {
         if (isset($data)) {
@@ -140,12 +140,12 @@ class Cache_Application extends Cache
     }
 
     /**
-    * unregister()
-    *
-    * Unregisters a variable from being stored.
-    *
-    * @param    string  Name of variable to unregister
-    */
+     * unregister()
+     *
+     * Unregisters a variable from being stored.
+     *
+     * @param string  Name of variable to unregister
+     */
     function unregister($varname)
     {
         if (isset($this->data[$varname])) {
@@ -154,23 +154,23 @@ class Cache_Application extends Cache
     }
 
     /**
-    * clear()
-    *
-    * Removes all stored data
-    */
+     * clear()
+     *
+     * Removes all stored data
+     */
     function clear()
     {
         $this->data = array();
     }
 
     /**
-    * getData()
-    *
-    * Use this to get a reference to the data to manipulate
-    * in calling script. Eg. $_APP =& $obj->getData();
-    *
-    * @return mixed   A reference to the data
-    */
+     * getData()
+     *
+     * Use this to get a reference to the data to manipulate
+     * in calling script. Eg. $_APP =& $obj->getData();
+     *
+     * @return mixed   A reference to the data
+     */
     function &getData()
     {
         return $this->data;

--- a/Cache/Container.php
+++ b/Cache/Container.php
@@ -22,128 +22,128 @@
 require_once 'Cache/Error.php';
 
 /**
-* Common base class of all cache storage container.
-*
-* To speed up things we do a preload you should know about, otherwise it might
-* play you a trick. The Cache controller classes (Cache/Cache, Cache/Output, ...)
-* usually do something like is (isCached($id) && !isExpired($id)) return $container->load($id).
-* if you implement isCached(), isExpired() and load() straight ahead, each of this
-* functions will result in a storage medium (db, file,...) access. This generates too much load.
-* Now, a simple speculative preload should saves time in most cases. Whenever
-* one of the mentioned methods is invoked we preload the cached dataset into class variables.
-* That means that we have only one storage medium access for the sequence
-*  (isCached($id) && !isExpired($id)) return $container->load($id).
-* The bad thing is that the preloaded data might be outdated meanwhile, which is
-* unlikely but for you power users, be warned. If you do not want the preload
-* you should switch it off by setting the class variable $preload to false. Anyway, this is
-* not recommended!
-*
-* @author   Ulf Wendel <ulf.wendel@phpdoc.de>
-* @version  $Id$
-* @package  Cache
-* @access   public
-* @abstract
-*/
+ * Common base class of all cache storage container.
+ *
+ * To speed up things we do a preload you should know about, otherwise it might
+ * play you a trick. The Cache controller classes (Cache/Cache, Cache/Output, ...)
+ * usually do something like is (isCached($id) && !isExpired($id)) return $container->load($id).
+ * if you implement isCached(), isExpired() and load() straight ahead, each of this
+ * functions will result in a storage medium (db, file,...) access. This generates too much load.
+ * Now, a simple speculative preload should saves time in most cases. Whenever
+ * one of the mentioned methods is invoked we preload the cached dataset into class variables.
+ * That means that we have only one storage medium access for the sequence
+ *  (isCached($id) && !isExpired($id)) return $container->load($id).
+ * The bad thing is that the preloaded data might be outdated meanwhile, which is
+ * unlikely but for you power users, be warned. If you do not want the preload
+ * you should switch it off by setting the class variable $preload to false. Anyway, this is
+ * not recommended!
+ *
+ * @author   Ulf Wendel <ulf.wendel@phpdoc.de>
+ * @version  $Id$
+ * @package  Cache
+ * @access   public
+ * @abstract
+ */
 class Cache_Container
 {
 
     /**
-    * Flag indicating wheter to preload datasets.
-    *
-    * See the class description for more details.
-    *
-    * @var  boolean
-    */
+     * Flag indicating wheter to preload datasets.
+     *
+     * See the class description for more details.
+     *
+     * @var boolean
+     */
     var $preload = true;
 
     /**
-    * ID of a preloaded dataset
-    *
-    * @var  string
-    */
+     * ID of a preloaded dataset
+     *
+     * @var string
+     */
     var $id = '';
 
     /**
-    * Cache group of a preloaded dataset
-    *
-    * @var  string
-    */
+     * Cache group of a preloaded dataset
+     *
+     * @var string
+     */
     var $group = '';
 
     /**
-    * Expiration timestamp of a preloaded dataset.
-    *
-    * @var  integer 0 means never, endless
-    */
+     * Expiration timestamp of a preloaded dataset.
+     *
+     * @var integer 0 means never, endless
+     */
     var $expires = 0;
 
     /**
-    * Value of a preloaded dataset.
-    *
-    * @var  string
-    */
+     * Value of a preloaded dataset.
+     *
+     * @var string
+     */
     var $cachedata = '';
 
     /**
-    * Preloaded userdata field.
-    *
-    * @var  string
-    */
+     * Preloaded userdata field.
+     *
+     * @var string
+     */
     var $userdata = '';
 
     /**
-    * Flag indicating that the dataset requested for preloading is unknown.
-    *
-    * @var  boolean
-    */
+     * Flag indicating that the dataset requested for preloading is unknown.
+     *
+     * @var boolean
+     */
     var $unknown = true;
 
     /**
-    * Encoding mode for cache data: base64 or addslashes() (slash).
-    *
-    * @var  string  base64 or slash
-    */
+     * Encoding mode for cache data: base64 or addslashes() (slash).
+     *
+     * @var string  base64 or slash
+     */
     var $encoding_mode = 'base64';
 
     /**
-    * Highwater mark - maximum space required by all cache entries.
-    *
-    * Whenever the garbage collection runs it checks the amount of space
-    * required by all cache entries. If it's more than n (highwater) bytes
-    * the garbage collection deletes as many entries as necessary to reach the
-    * lowwater mark.
-    *
-    * @var  int
-    * @see  lowwater
-    */
+     * Highwater mark - maximum space required by all cache entries.
+     *
+     * Whenever the garbage collection runs it checks the amount of space
+     * required by all cache entries. If it's more than n (highwater) bytes
+     * the garbage collection deletes as many entries as necessary to reach the
+     * lowwater mark.
+     *
+     * @var int
+     * @see lowwater
+     */
     var $highwater = 2048000;
 
 
     /**
-    * Lowwater mark
-    *
-    * @var  int
-    * @see  highwater
-    */
+     * Lowwater mark
+     *
+     * @var int
+     * @see highwater
+     */
     var $lowwater = 1536000;
 
 
     /**
-    * Options that can be set in every derived class using it's constructor.
-    *
-    * @var  array
-    */
+     * Options that can be set in every derived class using it's constructor.
+     *
+     * @var array
+     */
     var $allowed_options = array('encoding_mode', 'highwater', 'lowwater');
 
 
     /**
-    * Loads a dataset from the cache.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   mixed   dataset value or null on failure
-    * @access   public
-    */
+     * Loads a dataset from the cache.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return mixed   dataset value or null on failure
+     * @access public
+     */
     function load($id, $group)
     {
         if ($this->preload) {
@@ -163,13 +163,13 @@ class Cache_Container
     } // end func load
 
     /**
-    * Returns the userdata field of a cached data set.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   string  userdata
-    * @access   public
-    */
+     * Returns the userdata field of a cached data set.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return string  userdata
+     * @access public
+     */
     function getUserdata($id, $group)
     {
         if ($this->preload) {
@@ -189,14 +189,14 @@ class Cache_Container
     } // end func getUserdata
 
     /**
-    * Checks if a dataset is expired.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @param    integer maximum age timestamp
-    * @return   boolean
-    * @access   public
-    */
+     * Checks if a dataset is expired.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @param  integer maximum age timestamp
+     * @return boolean
+     * @access public
+     */
     function isExpired($id, $group, $max_age)
     {
         if ($this->preload) {
@@ -227,19 +227,19 @@ class Cache_Container
         // you feel fine, Ulf?
         if ($expired  = ($this->expires <= time() || ($max_age && ($this->expires <= $max_age))) ) {
 
-           $this->remove($id, $group);
-           $this->flushPreload();
+            $this->remove($id, $group);
+            $this->flushPreload();
         }
         return $expired;
     } // end func isExpired
 
     /**
-    * Checks if a dataset is cached.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    */
+     * Checks if a dataset is cached.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return boolean
+     */
     function isCached($id, $group)
     {
         if ($this->preload) {
@@ -256,32 +256,32 @@ class Cache_Container
     //
 
     /**
-    * Fetches a dataset from the storage medium.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   array   format: [expire date, cached data, user data]
-    * @throws   Cache_Error
-    * @abstract
-    */
+     * Fetches a dataset from the storage medium.
+     *
+     * @param    string  dataset ID
+     * @param    string  cache group
+     * @return   array   format: [expire date, cached data, user data]
+     * @throws   Cache_Error
+     * @abstract
+     */
     function fetch($id, $group)
     {
         return array(null, null, null);
     } // end func fetch
 
     /**
-    * Stores a dataset.
-    *
-    * @param    string  dataset ID
-    * @param    mixed   data to store
-    * @param    mixed   userdefined expire date
-    * @param    string  cache group
-    * @param    string  additional userdefined data
-    * @return   boolean
-    * @throws   Cache_Error
-    * @access   public
-    * @abstract
-    */
+     * Stores a dataset.
+     *
+     * @param    string  dataset ID
+     * @param    mixed   data to store
+     * @param    mixed   userdefined expire date
+     * @param    string  cache group
+     * @param    string  additional userdefined data
+     * @return   boolean
+     * @throws   Cache_Error
+     * @access   public
+     * @abstract
+     */
     function save($id, $data, $expire, $group, $userdata)
     {
         // QUESTION: Should we update the preload buffer instead?
@@ -291,14 +291,14 @@ class Cache_Container
     } // end func save
 
     /**
-    * Removes a dataset.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    * @access   public
-    * @abstract
-    */
+     * Removes a dataset.
+     *
+     * @param    string  dataset ID
+     * @param    string  cache group
+     * @return   boolean
+     * @access   public
+     * @abstract
+     */
     function remove($id, $group)
     {
         $this->flushPreload($id, $group);
@@ -306,13 +306,13 @@ class Cache_Container
     } // end func remove
 
     /**
-    * Flushes the cache - removes all caches datasets from the cache.
-    *
-    * @param    string      If a cache group is given only the group will be flushed
-    * @return   integer     Number of removed datasets, -1 on failure
-    * @access   public
-    * @abstract
-    */
+     * Flushes the cache - removes all caches datasets from the cache.
+     *
+     * @param    string      If a cache group is given only the group will be flushed
+     * @return   integer     Number of removed datasets, -1 on failure
+     * @access   public
+     * @abstract
+     */
     function flush($group)
     {
         $this->flushPreload();
@@ -320,40 +320,40 @@ class Cache_Container
     } // end func flush
 
     /**
-    * Checks if a dataset exists.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    * @access   public
-    * @abstract
-    */
+     * Checks if a dataset exists.
+     *
+     * @param    string  dataset ID
+     * @param    string  cache group
+     * @return   boolean
+     * @access   public
+     * @abstract
+     */
     function idExists($id, $group)
     {
         return null;
     } // end func idExists
 
     /**
-    * Starts the garbage collection.
-    *
-    * @param int $gc_maxlifetime The maximum lifetime (seconds) for a cache
-    *                            entry. Implemented by containers,
-    *
-    * @access   public
-    * @abstract
-    */
+     * Starts the garbage collection.
+     *
+     * @param int $gc_maxlifetime The maximum lifetime (seconds) for a cache
+     *                            entry. Implemented by containers,
+     *
+     * @access   public
+     * @abstract
+     */
     function garbageCollection($gc_maxlifetime)
     {
         $this->flushPreload();
     } // end func garbageCollection
 
     /**
-    * Does a speculative preload of a dataset
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   boolean
-    */
+     * Does a speculative preload of a dataset
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return boolean
+     */
     function preload($id, $group)
     {
         // whatever happens, remember the preloaded ID
@@ -378,18 +378,18 @@ class Cache_Container
     } // end func preload
 
     /**
-    * Flushes the internal preload buffer.
-    *
-    * save(), remove() and flush() must call this method
-    * to preevent differences between the preloaded values and
-    * the real cache contents.
-    *
-    * @param    string  dataset ID, if left out the preloaded values will be flushed.
-    *                   If given the preloaded values will only be flushed if they are
-    *                   equal to the given id and group
-    * @param    string  cache group
-    * @see  preload()
-    */
+     * Flushes the internal preload buffer.
+     *
+     * save(), remove() and flush() must call this method
+     * to preevent differences between the preloaded values and
+     * the real cache contents.
+     *
+     * @param string  dataset ID, if left out the preloaded values will be flushed.
+     *                   If given the preloaded values will only be flushed if they are
+     *                   equal to the given id and group
+     * @param string  cache group
+     * @see   preload()
+     */
     function flushPreload($id = '', $group = 'default')
     {
         if (!$id || ($this->id == $id && $this->group == $group)) {
@@ -404,13 +404,13 @@ class Cache_Container
     } // end func flushPreload
 
     /**
-    * Imports the requested datafields as object variables if allowed
-    *
-    * @param array $requested list of fields to be imported
-    *
-    * @return boolean True if all parametes in arg are accepted
-    * @access protected
-    */
+     * Imports the requested datafields as object variables if allowed
+     *
+     * @param array $requested list of fields to be imported
+     *
+     * @return boolean True if all parametes in arg are accepted
+     * @access protected
+     */
     function setOptions($requested)
     {
         $wasAccepted = true;
@@ -444,7 +444,7 @@ class Cache_Container
     /**
      * Verify that a configuration option has been set
      *
-     * @param string $optionName the option name 
+     * @param string $optionName the option name
      *
      * @return boolean
      * @access protected
@@ -455,7 +455,7 @@ class Cache_Container
     }
 
     /**
-     * Getter to allowed Configurations Options 
+     * Getter to allowed Configurations Options
      *
      * @return array The options you can set to Container
      * @access protected
@@ -466,10 +466,10 @@ class Cache_Container
     }
 
     /**
-    * Encodes the data for the storage container.
-    *
-    * @var  mixed data to encode
-    */
+     * Encodes the data for the storage container.
+     *
+     * @var mixed data to encode
+     */
     function encode($data)
     {
         if ($this->encoding_mode == 'base64') {
@@ -481,10 +481,10 @@ class Cache_Container
 
 
     /**
-    * Decodes the data from the storage container.
-    *
-    * @var  mixed
-    */
+     * Decodes the data from the storage container.
+     *
+     * @var mixed
+     */
     function decode($data)
     {
         if ($this->encoding_mode == 'base64') {
@@ -496,16 +496,16 @@ class Cache_Container
 
 
     /**
-    * Translates human readable/relative times in unixtime
-    *
-    * @param  mixed   can be in the following formats:
-    *               human readable          : yyyymmddhhmm[ss]] eg: 20010308095100
-    *               relative in seconds (1) : +xx              eg: +10
-    *               relative in seconds (2) : x <  946681200   eg: 10
-    *               absolute unixtime       : x < 2147483648   eg: 2147483648
-    *               see comments in code for details
-    * @return integer unix timestamp
-    */
+     * Translates human readable/relative times in unixtime
+     *
+     * @param  mixed   can be in the following formats:
+     *               human readable          : yyyymmddhhmm[ss]] eg: 20010308095100
+     *               relative in seconds (1) : +xx              eg: +10
+     *               relative in seconds (2) : x <  946681200   eg: 10
+     *               absolute unixtime       : x < 2147483648   eg: 2147483648
+     *               see comments in code for details
+     * @return integer unix timestamp
+     */
     function getExpiresAbsolute($expires)
     {
         if (!$expires) {

--- a/Cache/Container/mdb.php
+++ b/Cache/Container/mdb.php
@@ -24,60 +24,60 @@ require_once 'MDB.php';
 require_once 'Cache/Container.php';
 
 /**
-* PEAR/MDB Cache Container.
-*
-* NB: The field 'changed' has no meaning for the Cache itself. It's just there
-* because it's a good idea to have an automatically updated timestamp
-* field for debugging in all of your tables.
-*
-* A XML MDB-compliant schema example for the table needed is provided.
-* Look at the file "mdb_cache_schema.xml" for that.
-*
-* ------------------------------------------
-* A basic usage example:
-* ------------------------------------------
-*
-* $dbinfo = array(
-*   'database'    => 'dbname',
-*   'phptype'     => 'mysql',
-*   'username'    => 'root',
-*   'password'    => '',
-*   'cache_table' => 'cache'
-* );
-*
-*
-* $cache = new Cache('mdb', $dbinfo);
-* $id = $cache->generateID('testentry');
-*
-* if ($data = $cache->get($id)) {
-*    echo 'Cache hit.<br />Data: '.$data;
-*
-* } else {
-*   $data = 'data of any kind';
-*   $cache->save($id, $data);
-*   echo 'Cache miss.<br />';
-* }
-*
-* ------------------------------------------
-*
-* @author   Lorenzo Alberton <l.alberton at quipo.it>
-* @version  $Id$
-* @package  Cache
-*/
+ * PEAR/MDB Cache Container.
+ *
+ * NB: The field 'changed' has no meaning for the Cache itself. It's just there
+ * because it's a good idea to have an automatically updated timestamp
+ * field for debugging in all of your tables.
+ *
+ * A XML MDB-compliant schema example for the table needed is provided.
+ * Look at the file "mdb_cache_schema.xml" for that.
+ *
+ * ------------------------------------------
+ * A basic usage example:
+ * ------------------------------------------
+ *
+ * $dbinfo = array(
+ *   'database'    => 'dbname',
+ *   'phptype'     => 'mysql',
+ *   'username'    => 'root',
+ *   'password'    => '',
+ *   'cache_table' => 'cache'
+ * );
+ *
+ *
+ * $cache = new Cache('mdb', $dbinfo);
+ * $id = $cache->generateID('testentry');
+ *
+ * if ($data = $cache->get($id)) {
+ *    echo 'Cache hit.<br />Data: '.$data;
+ *
+ * } else {
+ *   $data = 'data of any kind';
+ *   $cache->save($id, $data);
+ *   echo 'Cache miss.<br />';
+ * }
+ *
+ * ------------------------------------------
+ *
+ * @author  Lorenzo Alberton <l.alberton at quipo.it>
+ * @version $Id$
+ * @package Cache
+ */
 class Cache_Container_mdb extends Cache_Container
 {
 
     /**
      * Name of the MDB table to store caching data
      *
-     * @see  Cache_Container_file::$filename_prefix
+     * @see Cache_Container_file::$filename_prefix
      */
     var $cache_table = '';
 
     /**
      * PEAR MDB object
      *
-     * @var  object PEAR_MDB
+     * @var object PEAR_MDB
      */
     var $db;
 
@@ -86,7 +86,7 @@ class Cache_Container_mdb extends Cache_Container
      *
      * @param mixed Array with connection info or dsn string
      */
-    function Cache_Container_mdb($options)
+    function __construct($options)
     {
         $this->setAllowedOptions(array('dsn', 'cache_table'));
         $this->setOptions($options);
@@ -104,10 +104,10 @@ class Cache_Container_mdb extends Cache_Container
     /**
      * Fetch in the db the data that matches input parameters
      *
-     * @param    string  dataset ID
-     * @param    string  cache group
-     * @return   mixed   dataset value or null/Cache_Error on failure
-     * @access   public
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return mixed   dataset value or null/Cache_Error on failure
+     * @access public
      */
     function fetch($id, $group)
     {
@@ -119,14 +119,19 @@ class Cache_Container_mdb extends Cache_Container
                 //no rows returned
                 $data = array(null, null, null);
             } else {
-                $clob = $this->db->fetchClob($res,0,'cachedata');
+                $clob = $this->db->fetchClob($res, 0, 'cachedata');
                 if (!MDB::isError($clob)) {
                     $cached_data = '';
                     while(!$this->db->endOfLOB($clob)) {
-                        if (MDB::isError($error =
-                                    $this->db->readLob($clob,$data,8000)<0)) {
-                            return new Cache_Error('MDB::query failed: '
-                                    . $error->getMessage(), __FILE__, __LINE__);
+                        if (MDB::isError(
+                            $error =
+                            $this->db->readLob($clob, $data, 8000)<0
+                        )
+                        ) {
+                            return new Cache_Error(
+                                'MDB::query failed: '
+                                . $error->getMessage(), __FILE__, __LINE__
+                            );
                         }
                         $cached_data .= $data;
                     }
@@ -153,8 +158,10 @@ class Cache_Container_mdb extends Cache_Container
                         $data = array(null, null, null);
                     }
                 } else {
-                    return new Cache_Error('MDB::query failed: '
-                             . $clob->getMessage(), __FILE__, __LINE__);
+                    return new Cache_Error(
+                        'MDB::query failed: '
+                        . $clob->getMessage(), __FILE__, __LINE__
+                    );
                 }
             }
             $this->db->freeResult($res);
@@ -172,24 +179,26 @@ class Cache_Container_mdb extends Cache_Container
 
         $res = $this->db->query($query);
         if (MDB::isError($res)) {
-            return new Cache_Error('MDB::query failed: '
-                . $this->db->errorMessage($res), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($res), __FILE__, __LINE__
+            );
         }
         return $data;
     }
 
-   /**
+    /**
      * Stores a dataset in the database
      *
      * If dataset_ID already exists, overwrite it with new data,
      * else insert data in a new record.
      *
-     * @param    string  dataset ID
-     * @param    mixed   data to be cached
-     * @param    integer expiration time
-     * @param    string  cache group
-     * @param    string  userdata
-     * @access   public
+     * @param  string  dataset ID
+     * @param  mixed   data to be cached
+     * @param  integer expiration time
+     * @param  string  cache group
+     * @param  string  userdata
+     * @access public
      */
     function save($id, $data, $expires, $group, $userdata)
     {
@@ -221,8 +230,10 @@ class Cache_Container_mdb extends Cache_Container
 
         if (MDB::isError($result)) {
             //Var_Dump::display($result);
-            return new Cache_Error('MDB::query failed: '
-                    . $this->db->errorMessage($result), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($result), __FILE__, __LINE__
+            );
         }
         unset($fields); //end first part of query
         $query2 = 'UPDATE '   . $this->cache_table
@@ -236,30 +247,36 @@ class Cache_Container_mdb extends Cache_Container
                             'Data' => $this->encode($data)
                         );
             if (!MDB::isError($clob = $this->db->createLob($char_lob))) {
-                $this->db->setParamClob($prepared_query,1,$clob,'cachedata');
-                if(MDB::isError($error=$this->db->executeQuery($prepared_query))) {
-                    return new Cache_Error('MDB::query failed: '
-                            . $error->getMessage() , __FILE__, __LINE__);
+                $this->db->setParamClob($prepared_query, 1, $clob, 'cachedata');
+                if(MDB::isError($error = $this->db->executeQuery($prepared_query))) {
+                    return new Cache_Error(
+                        'MDB::query failed: '
+                        . $error->getMessage(), __FILE__, __LINE__
+                    );
                 }
                 $this->db->destroyLob($clob);
             } else {
                 // creation of the handler object failed
-                return new Cache_Error('MDB::query failed: '
-                        . $clob->getMessage() , __FILE__, __LINE__);
+                return new Cache_Error(
+                    'MDB::query failed: '
+                    . $clob->getMessage(), __FILE__, __LINE__
+                );
             }
             $this->db->freePreparedQuery($prepared_query);
         } else {
             //prepared query failed
-            return new Cache_Error('MDB::query failed: '
-                    . $prepared_query->getMessage() , __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $prepared_query->getMessage(), __FILE__, __LINE__
+            );
         }
     }
 
     /**
      * Removes a dataset from the database
      *
-     * @param    string  dataset ID
-     * @param    string  cache group
+     * @param string  dataset ID
+     * @param string  cache group
      */
     function remove($id, $group)
     {
@@ -271,8 +288,10 @@ class Cache_Container_mdb extends Cache_Container
 
         $res = $this->db->query($query);
         if (MDB::isError($res)) {
-            return new Cache_Error('MDB::query failed: '
-                    . $this->db->errorMessage($res), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($res), __FILE__, __LINE__
+            );
         }
     }
 
@@ -280,7 +299,7 @@ class Cache_Container_mdb extends Cache_Container
      * Remove all cached data for a certain group, or empty
      * the cache table if no group is specified.
      *
-     * @param    string  cache group
+     * @param string  cache group
      */
     function flush($group = '')
     {
@@ -295,17 +314,19 @@ class Cache_Container_mdb extends Cache_Container
 
         $res = $this->db->query($query);
         if (MDB::isError($res)) {
-            return new Cache_Error('MDB::query failed: '
-                . $this->db->errorMessage($res), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($res), __FILE__, __LINE__
+            );
         }
     }
 
     /**
      * Check if a dataset ID/group exists.
      *
-     * @param    string  dataset ID
-     * @param    string  cache group
-     * @return   boolean
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return boolean
      */
     function idExists($id, $group)
     {
@@ -315,8 +336,10 @@ class Cache_Container_mdb extends Cache_Container
         echo $query;
         $res = $this->db->query($query);
         if (MDB::isError($res)) {
-            return new Cache_Error('MDB::query failed: '
-                    . $this->db->errorMessage($res), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($res), __FILE__, __LINE__
+            );
         }
         $row = $this->db->fetchInto($res);
 
@@ -329,7 +352,7 @@ class Cache_Container_mdb extends Cache_Container
     /**
      * Garbage collector.
      *
-     * @param    int maxlifetime
+     * @param int maxlifetime
      */
     function garbageCollection($maxlifetime)
     {
@@ -345,8 +368,10 @@ class Cache_Container_mdb extends Cache_Container
 
         $cachesize = $this->db->getOne($query);
         if (MDB::isError($cachesize)) {
-            return new Cache_Error('MDB::query failed: '
-                   . $this->db->errorMessage($cachesize), __FILE__, __LINE__);
+            return new Cache_Error(
+                'MDB::query failed: '
+                . $this->db->errorMessage($cachesize), __FILE__, __LINE__
+            );
         }
         //if cache is to big.
         if ($cachesize > $this->highwater) {
@@ -356,13 +381,15 @@ class Cache_Container_mdb extends Cache_Container
 
             $res = $this->db->query($query);
             if (MDB::isError($res)) {
-               return new Cache_Error('MDB::query failed: '
-                    . $this->db->errorMessage($res), __FILE__, __LINE__);
+                return new Cache_Error(
+                    'MDB::query failed: '
+                    . $this->db->errorMessage($res), __FILE__, __LINE__
+                );
             }
             $numrows = $this->db->numRows($res);
             $keep_size = 0;
             while ($keep_size < $this->lowwater && $numrows--) {
-                $entry = $this->db->fetchInto($res,MDB_FETCHMODE_ASSOC);
+                $entry = $this->db->fetchInto($res, MDB_FETCHMODE_ASSOC);
                 $keep_size += $entry['size'];
             }
 
@@ -372,8 +399,10 @@ class Cache_Container_mdb extends Cache_Container
 
             $res = $this->db->query($query);
             if (MDB::isError($res)) {
-               return new Cache_Error('MDB::query failed: '
-                    . $this->db->errorMessage($res), __FILE__, __LINE__);
+                return new Cache_Error(
+                    'MDB::query failed: '
+                    . $this->db->errorMessage($res), __FILE__, __LINE__
+                );
             }
         }
     }

--- a/Cache/Container/msession.php
+++ b/Cache/Container/msession.php
@@ -20,68 +20,68 @@
 require_once 'Cache/Container.php';
 
 /**
-* Stores cache contents in msessions.
-*
-* WARNING: experimental, untested
-*
-* @author   Ulf Wendel  <ulf.wendel@phpdoc.de>
-* @version  $Id$
-*/
+ * Stores cache contents in msessions.
+ *
+ * WARNING: experimental, untested
+ *
+ * @author  Ulf Wendel  <ulf.wendel@phpdoc.de>
+ * @version $Id$
+ */
 class Cache_Container_msession extends Cache_Container
 {
     /**
-    * Length of the Cache-Identifier
-    *
-    * Note that the PEAR-Cache prefixes the ID with an md5() value
-    * of the cache-group. A good value for the id_length
-    * depends on the maximum number of entries per cache group.
-    *
-    * @var  int
-    */
+     * Length of the Cache-Identifier
+     *
+     * Note that the PEAR-Cache prefixes the ID with an md5() value
+     * of the cache-group. A good value for the id_length
+     * depends on the maximum number of entries per cache group.
+     *
+     * @var int
+     */
     var $id_length = 32;
-    
-    
+
+
     /**
-    * Use msession_uniq to create a unique SID.
-    * 
-    * @var  boolean
-    */
+     * Use msession_uniq to create a unique SID.
+     *
+     * @var boolean
+     */
     var $uniq = true;
-    
-    
+
+
     /**
-    * Establish a connection to a msession server?
-    *
-    * @var  boolean
-    */
+     * Establish a connection to a msession server?
+     *
+     * @var boolean
+     */
     var $connect = true;
-   
-   
+
+
     /**
-    * msession host
-    *
-    * @var  string
-    */  
+     * msession host
+     *
+     * @var string
+     */
     var $host = null;
-    
-   
+
+
     /**
-    * msession port
-    *
-    * @var  string
-    */
+     * msession port
+     *
+     * @var string
+     */
     var $port = null;
-    
-    
+
+
     /**
-    * mesession server connection
-    *
-    * @var  resource msession
-    */
+     * mesession server connection
+     *
+     * @var resource msession
+     */
     var $ms = null;
 
-    
-    function Cache_Container_msession($options = '')
+
+    function __construct($options = '')
     {
         $this->setAllowedOptions(
             array('id_length', 'uniq', 'host', 'port', 'connect')
@@ -96,20 +96,20 @@ class Cache_Container_msession extends Cache_Container
             }
             if (!($this->ms = msession_connect($this->host, $this->port))) {
                 new Cache_Error(
-                    'Can not connect to the sever using host "' . 
+                    'Can not connect to the sever using host "' .
                     $this->host . '" on port "' . $this->port . '"',
                     __FILE__, __LINE__
                 );
             }
         }
-        
+
     } // end func contructor
 
     function fetch($id, $group)
     {
         $id = strtoupper(md5($group)) . $id;
         $group = msession_get($id, '_pear_cache_data', null);
-        
+
         if ($data == null) {
             return array(null, null, null);
         }
@@ -117,50 +117,50 @@ class Cache_Container_msession extends Cache_Container
     } // end func fetch
 
     /**
-    * Stores a dataset.
-    *
-    * WARNING: If you supply userdata it must not contain any linebreaks,
-    * otherwise it will break the filestructure.
-    */
+     * Stores a dataset.
+     *
+     * WARNING: If you supply userdata it must not contain any linebreaks,
+     * otherwise it will break the filestructure.
+     */
     function save($id, $cachedata, $expires, $group, $userdata)
     {
         $this->flushPreload($id, $group);
-        
+
         $cachedata      = $this->encode($cachedata);
         $expires_abs    = $this->getExpiresAbsolute($expires);
 
         $size = 1 + strlen($cachedata) + strlen($expires_abs) + strlen($userdata) + strlen($group);
         $size += strlen($size);
-        
+
         $data = array(
-                    'cachedata' => $cachedata, 
+                    'cachedata' => $cachedata,
                     'expires'   => $expires_abs,
                     'userdata'  => $userdata
                   );
         $id = strtoupper(md5($group)) . $id;
-                            
+
         msession_lock($id);
-        
+
         if (!msession_set($id, '_pear_cache', true)) {
             msession_unlock($id);
             return new Cache_Error("Can't write cache data.", __FILE__, __LINE__);
         }
-        
+
         if (!msession_set($id, '_pear_cache_data', $data)) {
             msession_unlock($id);
             return new Cache_Error("Can't write cache data.", __FILE__, __LINE__);
         }
-        
+
         if (!msession_set($id, '_pear_cache_group', $group)) {
             msession_unlock($id);
             return new Cache_Error("Can't write cache data.", __FILE__, __LINE__);
         }
-        
+
         if (!msession_set($id, '_pear_cache_size', $size)) {
             msession_unlock($id);
             return new Cache_Error("Can't write cache data.", __FILE__, __LINE__);
         }
-        
+
         // let msession do some GC as well
         // note that msession works different from the PEAR Cache.
         // msession deletes an entry if it has not been used for n-seconds.
@@ -182,14 +182,15 @@ class Cache_Container_msession extends Cache_Container
     function flush($group)
     {
         $this->flushPreload();
-      
+
         $sessions = msession_find('_pear_cache_group', $group);
         if (empty($sessions)) {
             return 0;
         }
 
-        foreach ($sessions as $k => $id)
+        foreach ($sessions as $k => $id) {
             messsion_destroy($id);
+        }
 
         return count($sessions);
     } // end func flush
@@ -200,24 +201,25 @@ class Cache_Container_msession extends Cache_Container
     } // end func idExists
 
     /**
-    * Deletes all expired files.
-    *
-    * Note: garbage collection should cause lot's of network traffic.
-    *
-    * @param    integer Maximum lifetime in seconds of an no longer used/touched entry
-    * @throws   Cache_Error
-    */
+     * Deletes all expired files.
+     *
+     * Note: garbage collection should cause lot's of network traffic.
+     *
+     * @param  integer Maximum lifetime in seconds of an no longer used/touched entry
+     * @throws Cache_Error
+     */
     function garbageCollection($maxlifetime)
     {
         $this->flushPreload();
-        
+
         $sessions = msession_find('_pear_cache', true);
-        if (empty($sessions))
+        if (empty($sessions)) {
             return true;
-        
+        }
+
         $total = 0;
         $entries = array();
-        
+
         foreach ($sessions as $k => $id) {
             $data = msession_get($id, '_pear_cache_data', null);
             if (null == $data) {
@@ -228,26 +230,26 @@ class Cache_Container_msession extends Cache_Container
                 msession_destroy($id);
                 continue;
             }
-            
+
             $size = msession_get($id, '_pear_cache_size', null);
             $total += $size;
             $entries[$data['expires']] = array($id, $size);
         }
-        
+
         if ($total > $this->highwater) {
-            
+
             krsort($entries);
             reset($entries);
-            
+
             while ($total > $this->lowwater && list($expires, $entry) = each($entries)) {
                 msession_destroy($entry[0]);
                 $total -= $entry[1];
             }
-            
+
         }
-        
+
         return true;
     } // end func garbageCollection
-    
+
 } // end class file
 ?>

--- a/Cache/Container/phplib.php
+++ b/Cache/Container/phplib.php
@@ -21,110 +21,109 @@
 require_once 'Cache/Container.php';
 
 /**
-* Stores cache data into a database table using PHPLibs DB abstraction.
-*
-* WARNING: Other systems might or might not support certain datatypes of 
-* the tables shown. As far as I know there's no large binary 
-* type in SQL-92 or SQL-99. Postgres seems to lack any 
-* BLOB or TEXT type, for MS-SQL you could use IMAGE, don't know 
-* about other databases. Please add sugestions for other databases to 
-* the inline docs.
-*
-* The field 'changed' is used by the garbage collection. Depending on 
-* your databasesystem you might have to subclass fetch() and garbageCollection().
-*
-* For _MySQL_ you need this DB table:
-*
-* CREATE TABLE cache (
-*   id          CHAR(32) NOT null DEFAULT '',
-*   cachegroup  VARCHAR(127) NOT null DEFAULT '',
-*   cachedata   BLOB NOT null DEFAULT '',
-*   userdata    VARCHAR(255) NOT null DEFAUL '',
-*   expires     INT(9) NOT null DEFAULT 0,
-*  
-*   changed     TIMESTAMP(14) NOT null,
-*  
-*   INDEX (expires),
-*   PRIMARY KEY (id, cachegroup)
-* )
-*
-* 
-* @author   Ulf Wendel  <ulf.wendel@phpdoc.de>, Sebastian Bergmann <sb@sebastian-bergmann.de>
-* @version  $Id$
-* @package  Cache
-* @see      save()
-*/
+ * Stores cache data into a database table using PHPLibs DB abstraction.
+ *
+ * WARNING: Other systems might or might not support certain datatypes of
+ * the tables shown. As far as I know there's no large binary
+ * type in SQL-92 or SQL-99. Postgres seems to lack any
+ * BLOB or TEXT type, for MS-SQL you could use IMAGE, don't know
+ * about other databases. Please add sugestions for other databases to
+ * the inline docs.
+ *
+ * The field 'changed' is used by the garbage collection. Depending on
+ * your databasesystem you might have to subclass fetch() and garbageCollection().
+ *
+ * For _MySQL_ you need this DB table:
+ *
+ * CREATE TABLE cache (
+ *   id          CHAR(32) NOT null DEFAULT '',
+ *   cachegroup  VARCHAR(127) NOT null DEFAULT '',
+ *   cachedata   BLOB NOT null DEFAULT '',
+ *   userdata    VARCHAR(255) NOT null DEFAUL '',
+ *   expires     INT(9) NOT null DEFAULT 0,
+ *
+ *   changed     TIMESTAMP(14) NOT null,
+ *
+ *   INDEX (expires),
+ *   PRIMARY KEY (id, cachegroup)
+ * )
+ *
+ * @author  Ulf Wendel  <ulf.wendel@phpdoc.de>, Sebastian Bergmann <sb@sebastian-bergmann.de>
+ * @version $Id$
+ * @package Cache
+ * @see     save()
+ */
 class Cache_Container_phplib extends Cache_Container
 {
     /**
-    * Name of the DB table to store caching data
-    * 
-    * @see  Cache_Container_file::$filename_prefix
-    */  
+     * Name of the DB table to store caching data
+     *
+     * @see Cache_Container_file::$filename_prefix
+     */
     var $cache_table = 'cache';
 
     /**
-    * PHPLib object
-    * 
-    * @var  object PEAR_DB
-    */
+     * PHPLib object
+     *
+     * @var object PEAR_DB
+     */
     var $db;
 
     /**
-    * Name of the PHPLib DB class to use
-    * 
-    * @var  string  
-    * @see  $db_path, $local_path
-    */
+     * Name of the PHPLib DB class to use
+     *
+     * @var string
+     * @see $db_path, $local_path
+     */
     var $db_class = '';
 
     /**
-    * Filename of your local.inc
-    * 
-    * If empty, 'local.inc' is assumed.
-    *
-    * @var       string
-    */
+     * Filename of your local.inc
+     *
+     * If empty, 'local.inc' is assumed.
+     *
+     * @var string
+     */
     var $local_file = '';
 
     /**
-    * Include path for you local.inc
-    *
-    * HINT: If your're not using PHPLib's prepend.php you must 
-    * take care that all classes (files) references by you 
-    * local.inc are included automatically. So you might 
-    * want to write a new local2.inc that only referrs to 
-    * the database class (file) you're using and includes all required files.
-    *
-    * @var  string  path to your local.inc - make sure to add a trailing slash
-    * @see  $local_file
-    */
+     * Include path for you local.inc
+     *
+     * HINT: If your're not using PHPLib's prepend.php you must
+     * take care that all classes (files) references by you
+     * local.inc are included automatically. So you might
+     * want to write a new local2.inc that only referrs to
+     * the database class (file) you're using and includes all required files.
+     *
+     * @var string  path to your local.inc - make sure to add a trailing slash
+     * @see $local_file
+     */
     var $local_path = '';
 
     /**
-    * Creates an instance of a phplib db class to use it for storage.
-    *
-    * @param    mixed   If empty the object tries to used the 
-    *                   preconfigured class variables. If given it 
-    *                   must be an array with:
-    *                     db_class => name of the DB class to use
-    *                   optional:
-    *                     db_file => filename of the DB class
-    *                     db_path => path to the DB class
-    *                     local_file => kind of local.inc
-    *                     local_patk => path to the local.inc
-    *                   see $local_path for some hints.s
-    * @see  $local_path
-    */
-    function Cache_Container_phplib($options = null)
+     * Creates an instance of a phplib db class to use it for storage.
+     *
+     * @param mixed   If empty the object tries to used the
+     *                   preconfigured class variables. If given it
+     *                   must be an array with:
+     *                     db_class => name of the DB class to use
+     *                   optional:
+     *                     db_file => filename of the DB class
+     *                     db_path => path to the DB class
+     *                     local_file => kind of local.inc
+     *                     local_patk => path to the local.inc
+     *                   see $local_path for some hints.s
+     * @see   $local_path
+     */
+    function __construct($options = null)
     {
         $this->setAllowedOptions(
             array('db_class', 'db_file', 'db_path', 'local_file', 'local_path')
         );
-        $this->setOptions($options)
+        $this->setOptions($options);
         if (!$this->hasBeenSet('db_class')) {
             return new Cache_Error(
-                'No database class specified.', 
+                'No database class specified.',
                 __FILE__, __LINE__
             );
         }
@@ -135,65 +134,69 @@ class Cache_Container_phplib extends Cache_Container
         if ($this->hasBeenSet('local_file')) {
             include_once $this->local_path . $this->local_file;
         }
-        // create a db object 
+        // create a db object
         $this->db = new $this->db_class;
     } // end constructor
 
     function fetch($id, $group)
     {
-        $query = sprintf("SELECT expires, cachedata, userdata FROM %s WHERE id = '%s' AND cachegroup = '%s'",
-                            $this->cache_table, 
-                            $id,
-                            $group
-                         );
+        $query = sprintf(
+            "SELECT expires, cachedata, userdata FROM %s WHERE id = '%s' AND cachegroup = '%s'",
+            $this->cache_table,
+            $id,
+            $group
+        );
         $this->db->query($query);
         if (!$this->db->Next_Record()) {
             return array(null, null, null);
         }
-        // last used required by the garbage collection   
-        // WARNING: might be MySQL specific         
-        $query = sprintf("UPDATE %s SET changed = (NOW() + 0) WHERE id = '%s' AND cachegroup = '%s'",
-                            $this->cache_table,
-                            $id,
-                            $group
-                          );
+        // last used required by the garbage collection
+        // WARNING: might be MySQL specific
+        $query = sprintf(
+            "UPDATE %s SET changed = (NOW() + 0) WHERE id = '%s' AND cachegroup = '%s'",
+            $this->cache_table,
+            $id,
+            $group
+        );
         $this->db->query($query);
         return array($this->db->f('expires'), $this->decode($this->db->f('cachedata')), $this->db->f('userdata'));
     } // end func fetch
 
     /**
-    * Stores a dataset.
-    * 
-    * WARNING: we use the SQL command REPLACE INTO this might be 
-    * MySQL specific. As MySQL is very popular the method should
-    * work fine for 95% of you.
-    */
+     * Stores a dataset.
+     *
+     * WARNING: we use the SQL command REPLACE INTO this might be
+     * MySQL specific. As MySQL is very popular the method should
+     * work fine for 95% of you.
+     */
     function save($id, $data, $expires, $group)
     {
         $this->flushPreload($id, $group);
 
-        $query = sprintf("REPLACE INTO %s (cachedata, expires, id, cachegroup) VALUES ('%s', %d, '%s', '%s')",
-                            $this->cache_table,
-                            addslashes($this->encode($data)),
-                            $this->getExpiresAbsolute($expires) ,
-                            $id,
-                            $group
-                         );
+        $query = sprintf(
+            "REPLACE INTO %s (cachedata, expires, id, cachegroup) VALUES ('%s', %d, '%s', '%s')",
+            $this->cache_table,
+            addslashes($this->encode($data)),
+            $this->getExpiresAbsolute($expires),
+            $id,
+            $group
+        );
         $this->db->query($query);
 
-        return (boolean)$this->db->affected_rows(); 
+        return (boolean)$this->db->affected_rows();
     } // end func save
 
     function remove($id, $group)
     {
         $this->flushPreload($id, $group);
         $this->db->query(
-                        sprintf("DELETE FROM %s WHERE id = '%s' AND cachegroup = '%s'",
-                            $this->cache_table,
-                            $id,
-                            $group
-                          )
-                    );
+            sprintf(
+                "DELETE FROM %s WHERE id = '%s' AND cachegroup = '%s'",
+                $this->cache_table,
+                $id,
+                $group
+            )
+        );
 
         return (boolean)$this->db->affected_rows();
     } // end func remove
@@ -203,9 +206,9 @@ class Cache_Container_phplib extends Cache_Container
         $this->flushPreload();
 
         if ($group) {
-            $this->db->query(sprintf("DELETE FROM %s WHERE cachegroup = '%s'", $this->cache_table, $group));    
+            $this->db->query(sprintf("DELETE FROM %s WHERE cachegroup = '%s'", $this->cache_table, $group));
         } else {
-            $this->db->query(sprintf("DELETE FROM %s", $this->cache_table));    
+            $this->db->query(sprintf("DELETE FROM %s", $this->cache_table));
         }
 
         return $this->db->affected_rows();
@@ -214,32 +217,35 @@ class Cache_Container_phplib extends Cache_Container
     function idExists($id, $group)
     {
         $this->db->query(
-                        sprintf("SELECT id FROM %s WHERE ID = '%s' AND cachegroup = '%s'", 
-                            $this->cache_table,
-                            $id, 
-                            $group
-                        )   
-                    );
+            sprintf(
+                "SELECT id FROM %s WHERE ID = '%s' AND cachegroup = '%s'",
+                $this->cache_table,
+                $id,
+                $group
+            )
+        );
 
-        return (boolean)$this->db->nf();                         
+        return (boolean)$this->db->nf();
     } // end func isExists
 
     function garbageCollection($maxlifetime)
     {
         $this->flushPreload();
 
-        $this->db->query( 
-                        sprintf("DELETE FROM %s WHERE (expires <= %d AND expires > 0) OR changed <= (NOW() - %d)",
-                            $this->cache_table, 
-                            time(),
-                            $maxlifetime
-                        )
-                    );
+        $this->db->query(
+            sprintf(
+                "DELETE FROM %s WHERE (expires <= %d AND expires > 0) OR changed <= (NOW() - %d)",
+                $this->cache_table,
+                time(),
+                $maxlifetime
+            )
+        );
 
         //check for total size of cache
-        $query = sprintf('select sum(length(cachedata)) as CacheSize from %s',
-                         $this->cache_table
-                       );
+        $query = sprintf(
+            'select sum(length(cachedata)) as CacheSize from %s',
+            $this->cache_table
+        );
 
         $this->db->query($query);
         $this->db->Next_Record();
@@ -247,9 +253,10 @@ class Cache_Container_phplib extends Cache_Container
         //if cache is to big.
         if ($cachesize > $this->highwater) {
             //find the lowwater mark.
-            $query = sprintf('select length(cachedata) as size, changed from %s order by changed DESC',
-                                     $this->cache_table
-                       );
+            $query = sprintf(
+                'select length(cachedata) as size, changed from %s order by changed DESC',
+                $this->cache_table
+            );
             $this->db->query($query);
 
             $keep_size=0;
@@ -257,9 +264,10 @@ class Cache_Container_phplib extends Cache_Container
                 $keep_size += $this->db->f('size');
             }
             //delete all entries, which were changed before the "lowwwater mark"
-            $query = sprintf('delete from %s where changed <= '.$this->db->f('changed'),
-                                     $this->cache_table
-                                   );
+            $query = sprintf(
+                'delete from %s where changed <= '.$this->db->f('changed'),
+                $this->cache_table
+            );
 
             $this->db->query($query);
         }

--- a/Cache/Container/shm.php
+++ b/Cache/Container/shm.php
@@ -21,104 +21,104 @@
 require_once 'Cache/Container.php';
 
 /**
-* Stores cache data into shared memory.
-*
-* Well, this is not a very efficient implementation. Indeed it's much 
-* slower than the file container as far as my tests showed. Files are 
-* cached by most operating systems and it will be hard to write a faster 
-* caching algorithm using PHP.
-*
-* @author   Ulf Wendel <ulf.wendel@phpdoc.de>
-* @version  $Id$
-* @package  Cache
-*/
+ * Stores cache data into shared memory.
+ *
+ * Well, this is not a very efficient implementation. Indeed it's much
+ * slower than the file container as far as my tests showed. Files are
+ * cached by most operating systems and it will be hard to write a faster
+ * caching algorithm using PHP.
+ *
+ * @author  Ulf Wendel <ulf.wendel@phpdoc.de>
+ * @version $Id$
+ * @package Cache
+ */
 class Cache_Container_shm extends Cache_Container
 {
     /**
-    * Key of the semaphore used to sync the SHM access
-    * 
-    * @var  int
-    */
+     * Key of the semaphore used to sync the SHM access
+     *
+     * @var int
+     */
     var $sem_key = null;
 
     /**
-    * Permissions of the semaphore used to sync the SHM access
-    * 
-    * @var  int
-    */
+     * Permissions of the semaphore used to sync the SHM access
+     *
+     * @var int
+     */
     var $sem_perm = 0644;
 
     /**
-    * Semaphore handler
-    * 
-    * @var  resource
-    */
+     * Semaphore handler
+     *
+     * @var resource
+     */
     var $sem_id = null;
 
     /**
-    * Key of the shared memory block used to store cache data
-    *
-    * @var  int
-    */
+     * Key of the shared memory block used to store cache data
+     *
+     * @var int
+     */
     var $shm_key = null;
 
     /**
-    * Size of the shared memory block used
-    * 
-    * Note: the container does only use _one_ shm block no more!
-    * 
-    * @var  int
-    */        
+     * Size of the shared memory block used
+     *
+     * Note: the container does only use _one_ shm block no more!
+     *
+     * @var int
+     */
     var $shm_size = 131072;
 
     /**
-    * Permissions of the shared memory block
-    * 
-    * @var  int
-    */
+     * Permissions of the shared memory block
+     *
+     * @var int
+     */
     var $shm_perm = 0644;
 
     /**
-    * Shared memory handler
-    * 
-    * @var resource
-    */
+     * Shared memory handler
+     *
+     * @var resource
+     */
     var $shm_id = null;
 
     /**
-    * Hash of cache entries
-    * 
-    * Used by the garbage collection to find old entries.
-    *
-    * @var  array
-    */
+     * Hash of cache entries
+     *
+     * Used by the garbage collection to find old entries.
+     *
+     * @var array
+     */
     var $entries = array();
 
     /**
-    * Number of bytes consumed by the cache
-    * 
-    * @var  int
-    */
+     * Number of bytes consumed by the cache
+     *
+     * @var int
+     */
     var $total_size = 0;
 
     /**
-    * Creates a shared memory container
-    *
-    * @param array    shm_key, sem_key, shm_size, sem_perm, shm_perm
-    */    
-    function Cache_Container_shm($options = null)
+     * Creates a shared memory container
+     *
+     * @param array    shm_key, sem_key, shm_size, sem_perm, shm_perm
+     */
+    function __construct($options = null)
     {
         $this->setAllowedOptions(
-            array('shm_key',  'sem_key', 
+            array('shm_key',  'sem_key',
                   'shm_size', 'sem_perm',
                   'shm_perm'
                  )
         );
-        $this->setOptions($options)
+        $this->setOptions($options);
 
         // Cache::Container high- and lowwater defaults should be overridden if
         // not already done by the user
-        if (!$this->hasBeenSet('highwater')) { 
+        if (!$this->hasBeenSet('highwater')) {
             $this->highwater = round(0.75 * 131072);
         }
         if (!$this->hasBeenSet('lowwater')) {
@@ -129,16 +129,18 @@ class Cache_Container_shm extends Cache_Container
         }
         //get SHM and Semaphore handles
         if (!($this->shm_id = shmop_open($this->shm_key, 'c', $this->shm_perm, $this->shm_size))) {
-            new Cache_Error("Can't open SHM segment '{$this->shm_key}', size '{$this->shm_size}'.",
-                            __FILE__,
-                            __LINE__
-                           );
+            new Cache_Error(
+                "Can't open SHM segment '{$this->shm_key}', size '{$this->shm_size}'.",
+                __FILE__,
+                __LINE__
+            );
         }
         if (!($this->sem_id = sem_get($this->sem_key, 1, $this->sem_perm))) {
-            new Cache_Error("Can't get semaphore '{$this->sem_key}' using perms '{$this->sem_perm}'.",
-                            __FILE__,
-                            __LINE__
-                           );
+            new Cache_Error(
+                "Can't get semaphore '{$this->sem_key}' using perms '{$this->sem_perm}'.",
+                __FILE__,
+                __LINE__
+            );
         }
     } // end constructor
 
@@ -251,7 +253,7 @@ class Cache_Container_shm extends Cache_Container
         $this->entries = array();
         $this->total_size = 0;
 
-        return $cachedata;           
+        return $cachedata;
     } // end func garbageCollection
 
     function doGarbageCollection($maxlifetime, &$cachedata)

--- a/Cache/Container/trifile.php
+++ b/Cache/Container/trifile.php
@@ -30,7 +30,7 @@ require_once 'Cache/Container/file.php';
  *
  * See http://atomized.org/PEAR/Cache_trifile.html for more information.
  *
- * @author Ian Eure <ieure@php.net>
+ * @author  Ian Eure <ieure@php.net>
  * @version 1.0
  */
 class Cache_Container_trifile extends Cache_Container_file
@@ -38,8 +38,8 @@ class Cache_Container_trifile extends Cache_Container_file
     /**
      * Fetch cached file.
      *
-     * @param string $id Cache ID to fetch
-     * @param string $group Group to fetch from
+     * @param  string $id    Cache ID to fetch
+     * @param  string $group Group to fetch from
      * @return array 1-dimensional array in the format: expiration,data,userdata
      */
     function fetch($id, $group)
@@ -58,7 +58,7 @@ class Cache_Container_trifile extends Cache_Container_file
                 file_get_contents($this->_getUDFile($file))
         );
     }
-    
+
     /**
      * Get the file to store cache data in.
      *
@@ -71,7 +71,7 @@ class Cache_Container_trifile extends Cache_Container_file
         $file = basename($file);
         return $dir.'/.'.$file;
     }
-    
+
     /**
      * Get the file to store expiration data in.
      *
@@ -82,7 +82,7 @@ class Cache_Container_trifile extends Cache_Container_file
     {
         return $this->_getFile($file).'.exp';
     }
-    
+
     /**
      * Get the file to store user data in.
      *
@@ -93,15 +93,15 @@ class Cache_Container_trifile extends Cache_Container_file
     {
         return $this->_getFile($file).'.dat';
     }
-    
+
     /**
      * Cache file
      *
-     * @param string $id Cache ID
-     * @param mixed $cachedata Data to cache
-     * @param mixed $expires When the data expires
-     * @param string $group Cache group to store data in
-     * @param mixed $userdata Additional data to store
+     * @param  string $id        Cache ID
+     * @param  mixed  $cachedata Data to cache
+     * @param  mixed  $expires   When the data expires
+     * @param  string $group     Cache group to store data in
+     * @param  mixed  $userdata  Additional data to store
      * @return boolean true on success, false otherwise
      */
     function save($id, $cachedata, $expires, $group, $userdata)
@@ -132,26 +132,27 @@ class Cache_Container_trifile extends Cache_Container_file
     /**
      * Save data in a file
      *
-     * @param string $file File to save data in
-     * @param string $data Data to save
+     * @param  string $file File to save data in
+     * @param  string $data Data to save
      * @return mixed true on success, Cache_Error otherwise
      */
     function _saveData($file, $data)
     {
         // Save data
-        if (!($fh = @fopen($file, 'wb')))
+        if (!($fh = @fopen($file, 'wb'))) {
             return new Cache_Error("Can't access '$file' to store cache data. Check access rights and path.", __FILE__, __LINE__);
-        
+        }
+
         if ($this->fileLocking) {
             flock($fh, LOCK_EX);
         }
-        
+
         fwrite($fh, $data);
-        
+
         if ($this->fileLocking) {
             flock($fh, LOCK_UN);
         }
-        
+
         fclose($fh);
         return true;
     }

--- a/Cache/Error.php
+++ b/Cache/Error.php
@@ -20,33 +20,34 @@
 require_once 'PEAR.php';
 
 /**
-* Cache Error class
-* 
-* @package Cache
-*/
+ * Cache Error class
+ *
+ * @package Cache
+ */
 class Cache_Error extends PEAR_Error
 {
 
 
-  /**
-  * Prefix of all error messages.
-  * 
-  * @var  string
-  */
-  var $error_message_prefix = 'Cache-Error: ';
-  
-  /**
-  * Creates an cache error object.
-  * 
-  * @param  string  error message
-  * @param  string  file where the error occured
-  * @param  string  linenumber where the error occured
-  */
-  function Cache_Error($msg, $file = __FILE__, $line = __LINE__) {
-    
-    $this->PEAR_Error(sprintf("%s [%s on line %d].", $msg, $file, $line));
-    
-  } // end func Cache_Error
-  
+    /**
+     * Prefix of all error messages.
+     *
+     * @var string
+     */
+    var $error_message_prefix = 'Cache-Error: ';
+
+    /**
+     * Creates an cache error object.
+     *
+     * @param string  error message
+     * @param string  file where the error occured
+     * @param string  linenumber where the error occured
+     */
+    function __construct($msg, $file = __FILE__, $line = __LINE__)
+    {
+
+        $this->PEAR_Error(sprintf("%s [%s on line %d].", $msg, $file, $line));
+
+    } // end func Cache_Error
+
 } // end class Cache_Error
 ?>

--- a/Cache/Function.php
+++ b/Cache/Function.php
@@ -20,91 +20,90 @@
 require_once 'Cache.php';
 
 /**
-* Function_Cache
-*
-* Purpose:
-*
-*   Caching the result and output of functions.
-*
-* Example:
-*
-*   require_once 'Cache/Function.php';
-*
-*   class foo {
-*     function bar($test) {
-*       echo "foo::bar($test)<br>";
-*     }
-*   }
-*
-*   class bar {
-*     function foobar($object) {
-*       echo '$'.$object.'->foobar('.$object.')<br>';
-*     }
-*   }
-*
-*   $bar = new bar;
-*
-*   function foobar() {
-*     echo 'foobar()';
-*   }
-*
-*   $cache = new Cache_Function();
-*
-*   $cache->call('foo::bar', 'test');
-*   $cache->call('bar->foobar', 'bar');
-*   $cache->call('foobar');
-*
-* Note:
-* 
-*   You cannot cache every function. You should only cache 
-*   functions that only depend on their arguments and don't use
-*   global or static variables, don't rely on database queries or 
-*   files, and so on.
-* 
-* @author       Sebastian Bergmann <sb@sebastian-bergmann.de>
-* @module       Function_Cache
-* @modulegroup  Function_Cache
-* @package      Cache
-* @version      $Revision$
-* @access       public
-*/
+ * Function_Cache
+ *
+ * Purpose:
+ *
+ *   Caching the result and output of functions.
+ *
+ * Example:
+ *
+ *   require_once 'Cache/Function.php';
+ *
+ *   class foo {
+ *     function bar($test) {
+ *       echo "foo::bar($test)<br>";
+ *     }
+ *   }
+ *
+ *   class bar {
+ *     function foobar($object) {
+ *       echo '$'.$object.'->foobar('.$object.')<br>';
+ *     }
+ *   }
+ *
+ *   $bar = new bar;
+ *
+ *   function foobar() {
+ *     echo 'foobar()';
+ *   }
+ *
+ *   $cache = new Cache_Function();
+ *
+ *   $cache->call('foo::bar', 'test');
+ *   $cache->call('bar->foobar', 'bar');
+ *   $cache->call('foobar');
+ *
+ * Note:
+ *
+ *   You cannot cache every function. You should only cache
+ *   functions that only depend on their arguments and don't use
+ *   global or static variables, don't rely on database queries or
+ *   files, and so on.
+ *
+ * @author      Sebastian Bergmann <sb@sebastian-bergmann.de>
+ * @module      Function_Cache
+ * @modulegroup Function_Cache
+ * @package     Cache
+ * @version     $Revision$
+ * @access      public
+ */
 class Cache_Function extends Cache
 {
     var $expires;
 
     /**
-    * Constructor
-    *
-    * @param    string  Name of container class
-    * @param    array   Array with container class options
-    * @param    integer Number of seconds for which to cache
-    */
-    function Cache_Function($container  = 'file',
-                            $container_options = array('cache_dir'       => '.',
-                                                       'filename_prefix' => 'cache_'
-                                                      ),
-                            $expires = 3600
-                           )
-    {
-      $this->Cache($container, $container_options);
-      $this->expires = $expires;      
+     * Constructor
+     *
+     * @param string  Name of container class
+     * @param array   Array with container class options
+     * @param integer Number of seconds for which to cache
+     */
+    function __construct($container  = 'file',
+        $container_options = ['cache_dir' => '.',
+            'filename_prefix' => 'cache_'
+            ],
+        $expires = 3600
+    ) {
+        $this->Cache($container, $container_options);
+        $this->expires = $expires;
     }
 
     /**
-    * PEAR-Deconstructor
-    * Call deconstructor of parent
-    */
+     * PEAR-Deconstructor
+     * Call deconstructor of parent
+     */
     function _Cache_Function()
     {
         $this->_Cache();
     }
 
     /**
-    * Calls a cacheable function or method.
-    *
-    * @return mixed $result
-    * @access public
-    */
+     * Calls a cacheable function or method.
+     *
+     * @return mixed $result
+     * @access public
+     */
     function call()
     {
         // get arguments

--- a/Cache/Graphics.php
+++ b/Cache/Graphics.php
@@ -20,162 +20,161 @@
 require_once 'Cache.php';
 
 /**
-* Graphics disk cache.
-* 
-* The usual way to create images is to pass some arguments that describe the image 
-* to a script that dynamically creates an image. For every image of a page 
-* a new PHP interpreter gets started. This is a good way to kill your webserver.
-* 
-* When dealing with dynamically generated images you should not call another script 
-* to generate the images but generate the images by the script that produces the page
-* that contains the images. This is a major improvement but it's only half the way.
-* 
-* There's no need to rerender an image on every request. A simple disk cache can reduce
-* the computation time dramatically. This is what the class graphics_cache is for. 
-* 
-* Usage:
-* 
-* // create an instance of the graphics cache
-* $cache = new graphics_cache;
-*
-* $img = ImageCreate(...);
-*
-* // compute an ID for your image based on typical parameters
-* $id = m5d( $size, $colors, $label);
-* 
-* // check if it's cached
-* if (!($link = $cache->getImageLink($id, 'gif'))) {
-*  
-*   // hmmm, it's not cached, create it
-*   ...
-*   // cacheImageLink() and cacheImage() make the ImageGIF() call!
-*   // cacheImage() returns the value of ImageGIF() [etc.], cacheImageLink() returns a URL
-*   $link = $cache->cacheImageLink($id, $img, 'gif');
-* 
-* }
-*
-* // Ok, let's build the ImageLink
-* $size = getImageSize($link[0]);
-* printf('<img src="%s" %s>', $link[1], $size[3]);
-*
-* // for cacheImage():
-* // header('Content-type: image/gif'); print $cache->cacheImage($id, $img, 'gif');
-* 
-*
-* The class requires PHP 4.0.2+ [ImageType()]. Note that cacheImage() works with
-* the output buffer. Modify it if required!
-*
-* @author   Ulf Wendel <ulf.wendel@phpdoc.de>
-* @version  $Id$
-* @package  Cache
-*/
+ * Graphics disk cache.
+ *
+ * The usual way to create images is to pass some arguments that describe the image
+ * to a script that dynamically creates an image. For every image of a page
+ * a new PHP interpreter gets started. This is a good way to kill your webserver.
+ *
+ * When dealing with dynamically generated images you should not call another script
+ * to generate the images but generate the images by the script that produces the page
+ * that contains the images. This is a major improvement but it's only half the way.
+ *
+ * There's no need to rerender an image on every request. A simple disk cache can reduce
+ * the computation time dramatically. This is what the class graphics_cache is for.
+ *
+ * Usage:
+ *
+ * // create an instance of the graphics cache
+ * $cache = new graphics_cache;
+ *
+ * $img = ImageCreate(...);
+ *
+ * // compute an ID for your image based on typical parameters
+ * $id = m5d( $size, $colors, $label);
+ *
+ * // check if it's cached
+ * if (!($link = $cache->getImageLink($id, 'gif'))) {
+ *
+ *   // hmmm, it's not cached, create it
+ *   ...
+ *   // cacheImageLink() and cacheImage() make the ImageGIF() call!
+ *   // cacheImage() returns the value of ImageGIF() [etc.], cacheImageLink() returns a URL
+ *   $link = $cache->cacheImageLink($id, $img, 'gif');
+ *
+ * }
+ *
+ * // Ok, let's build the ImageLink
+ * $size = getImageSize($link[0]);
+ * printf('<img src="%s" %s>', $link[1], $size[3]);
+ *
+ * // for cacheImage():
+ * // header('Content-type: image/gif'); print $cache->cacheImage($id, $img, 'gif');
+ *
+ *
+ * The class requires PHP 4.0.2+ [ImageType()]. Note that cacheImage() works with
+ * the output buffer. Modify it if required!
+ *
+ * @author  Ulf Wendel <ulf.wendel@phpdoc.de>
+ * @version $Id$
+ * @package Cache
+ */
 class Cache_Graphics extends Cache
 {
 
 
     /**
-    * Cache URL prefix.
-    * 
-    * Make sure that the cache URL prefix points to the $cache_dir, otherwise
-    * your links will be broken. Use setCacheURL to specify the cache_url and 
-    * setCacheDir() for the cache_dir.
-    * 
-    * @var  string
-    * @see  setCacheURL(), setCacheDir()
-    */
+     * Cache URL prefix.
+     *
+     * Make sure that the cache URL prefix points to the $cache_dir, otherwise
+     * your links will be broken. Use setCacheURL to specify the cache_url and
+     * setCacheDir() for the cache_dir.
+     *
+     * @var string
+     * @see setCacheURL(), setCacheDir()
+     */
     var $cache_url = '';
 
     /**
-    * Directory where cached files get stored.
-    * s
-    * Make sure that the cache_dir is writable and offers enough space. Check 
-    * also if your cache_url points to the directory. Use setCacheDir() to set
-    * the variable.
-    * 
-    * @var  string
-    * @see  setCacheDir(), setCacheURL()
-    */
+     * Directory where cached files get stored.
+     * s
+     * Make sure that the cache_dir is writable and offers enough space. Check
+     * also if your cache_url points to the directory. Use setCacheDir() to set
+     * the variable.
+     *
+     * @var string
+     * @see setCacheDir(), setCacheURL()
+     */
     var $cache_dir = '';
 
     /**
-    * Nameprefix of cached files.
-    * 
-    * Per default the prefix "graphics_" gets used. You might use this 
-    * for versioning or to ease (manual) clean ups.
-    *
-    * @var      string
-    */
+     * Nameprefix of cached files.
+     *
+     * Per default the prefix "graphics_" gets used. You might use this
+     * for versioning or to ease (manual) clean ups.
+     *
+     * @var string
+     */
     var $cache_file_prefix = 'graphics_';
-    
-    
+
+
     /**
-    * Cache container group.
-    *
-    * @var      string
-    */
+     * Cache container group.
+     *
+     * @var string
+     */
     var $cache_group = 'graphics';
 
-    
+
     /**
-    * Mapping from supported image type to a ImageType() constant.
-    * 
-    * Referr to the PHP manual for more informations on ImageType()
-    * 
-    * @var  array
-    * @link http://www.php.net/ImageType
-    */
+     * Mapping from supported image type to a ImageType() constant.
+     *
+     * Referr to the PHP manual for more informations on ImageType()
+     *
+     * @var  array
+     * @link http://www.php.net/ImageType
+     */
     var $imagetypes = array(
-                                'gif'   => IMG_GIF, 
+                                'gif'   => IMG_GIF,
                                 'jpg'   => IMG_JPG,
                                 'png'   => IMG_PNG,
                                 'wbmp'  => IMG_WBMP
                             );
 
-                            
+
     /**
-    * Instantiates a cache file container.
-    *
-    */
-    function Cache_Graphics()
+     * Instantiates a cache file container.
+     */
+    function __construct()
     {
         $this->Cache('file', array('cache_dir' => $this->cache_dir, 'filename_prefix' => $this->cache_file_prefix));
-        
+
     } // end constructor
 
-    
+
     /**
-    * Returns the content of a cached image file.
-    * 
-    * This function can be used to send the image directly to the browser.
-    * Make sure that you send a correspondending header before sending the image itself.
-    *
-    * Always try to get the image from the cache before you compute it. See 
-    * the class docs for an example.
-    *
-    * @param    string  Image-ID
-    * @param    string  Image type: gif, jpg, png, wbmp
-    * @return   string  Image file contents if a cached file exists otherwise an empty string
-    * @see      cacheImage()
-    */                                    
+     * Returns the content of a cached image file.
+     *
+     * This function can be used to send the image directly to the browser.
+     * Make sure that you send a correspondending header before sending the image itself.
+     *
+     * Always try to get the image from the cache before you compute it. See
+     * the class docs for an example.
+     *
+     * @param  string  Image-ID
+     * @param  string  Image type: gif, jpg, png, wbmp
+     * @return string  Image file contents if a cached file exists otherwise an empty string
+     * @see    cacheImage()
+     */
     function getImage($id, $format = 'png')
     {
         $id = $this->generateID($id, $format);
         return $this->get($id, $this->cache_group);
     } // end func getImage
 
-    
+
     /**
-    * Returns an array with a link to the cached image and the image file path.
-    * 
-    * Always try to get the image from the cache before you compute it. See 
-    * the class docs for an example.
-    *
-    * @param    string  Image-ID
-    * @param    string  Image type: gif, jpg, png, wbmp
-    * @return   array   [ full path to the image file, image url ]
-    * @throw    Cache_Error
-    * @see      cacheImageLink()
-    */
+     * Returns an array with a link to the cached image and the image file path.
+     *
+     * Always try to get the image from the cache before you compute it. See
+     * the class docs for an example.
+     *
+     * @param  string  Image-ID
+     * @param  string  Image type: gif, jpg, png, wbmp
+     * @return array   [ full path to the image file, image url ]
+     * @throw  Cache_Error
+     * @see    cacheImageLink()
+     */
     function getImageLink($id, $format = 'png')
     {
         $id = $this->generateID($id, $format);
@@ -186,28 +185,28 @@ class Cache_Graphics extends Cache
 
         return array($this->container->getFilename($id, $this->cache_group), $file);
     } // end func getImageLink
-    
+
 
     /**
-    * Create an image from the given image handler, cache it and return the file content.
-    *
-    * Always try to retrive the image from the cache before you compute it.
-    * 
-    * Warning: this function uses the output buffer. If you expect collisions 
-    * modify the code.
-    *
-    * @param    string  Image-ID. Used as a part of the cache filename.
-    *                   Use md5() to generate a "unique" ID for your image
-    *                   based on characteristic values such as the color, size etc.
-    * @param    string  Image handler to create the image from.
-    * @param    string  Image type: gif, jpg, png, wbmp. Also used as filename suffix.
-    *                   If an unsupported type is requested the functions tries to 
-    *                   fallback to a supported type before throwing an exeption.
-    * @return   string  Image content returned by ImageGIF/... 
-    * @throws   Cache_Error
-    * @access   public
-    * @see      getImage()
-    */
+     * Create an image from the given image handler, cache it and return the file content.
+     *
+     * Always try to retrive the image from the cache before you compute it.
+     *
+     * Warning: this function uses the output buffer. If you expect collisions
+     * modify the code.
+     *
+     * @param  string  Image-ID. Used as a part of the cache filename.
+     *                   Use md5() to generate a "unique" ID for your image
+     *                   based on characteristic values such as the color, size etc.
+     * @param  string  Image handler to create the image from.
+     * @param  string  Image type: gif, jpg, png, wbmp. Also used as filename suffix.
+     *                   If an unsupported type is requested the functions tries to
+     *                   fallback to a supported type before throwing an exeption.
+     * @return string  Image content returned by ImageGIF/...
+     * @throws Cache_Error
+     * @access public
+     * @see    getImage()
+     */
     function cacheImage($id, $img, $format = 'png')
     {
         if (!$id) {
@@ -231,10 +230,10 @@ class Cache_Graphics extends Cache
         if ($image = $this->get($id, $this->cache_group)) {
             return $image;
         }
-        // save the image to the output buffer, write it to disk and 
+        // save the image to the output buffer, write it to disk and
         // return the image.
         ob_end_clean();
-        ob_start(); 
+        ob_start();
 
         if (strtoupper($format) == 'JPG') {
             $genFormat = 'JPEG';
@@ -256,41 +255,42 @@ class Cache_Graphics extends Cache
 
         return $image;
     } // end func cacheImage
-    
+
 
     /**
-    * Create an image from the given image handler, cache it and return a url and the file path of the image.
-    *
-    * Always try to retrive the image from the cache before you compute it.
-    *
-    * @param    string  Image-ID. Used as a part of the cache filename.
-    *                   Use md5() to generate a "unique" ID for your image
-    *                   based on characteristic values such as the color, size etc.
-    * @param    string  Image handler to create the image from.
-    * @param    string  Image type: gif, jpg, png, wbmp. Also used as filename suffix.
-    *                   If an unsupported type is requested the functions tries to 
-    *                   fallback to a supported type before throwing an exeption.
-    * @return   array  [ full path to the image file, image url ]
-    * @throws   Cache_Error
-    * @access   public
-    */
+     * Create an image from the given image handler, cache it and return a url and the file path of the image.
+     *
+     * Always try to retrive the image from the cache before you compute it.
+     *
+     * @param  string  Image-ID. Used as a part of the cache filename.
+     *                   Use md5() to generate a "unique" ID for your image
+     *                   based on characteristic values such as the color, size etc.
+     * @param  string  Image handler to create the image from.
+     * @param  string  Image type: gif, jpg, png, wbmp. Also used as filename suffix.
+     *                   If an unsupported type is requested the functions tries to
+     *                   fallback to a supported type before throwing an exeption.
+     * @return array  [ full path to the image file, image url ]
+     * @throws Cache_Error
+     * @access public
+     */
     function cacheImageLink($id, &$img, $format = 'png')
     {
         if (!$id) {
-            return new Cache_Error ('You must provide an ID for and image to be cached!', __FILE__, __LINE__);
-         }
+            return new Cache_Error('You must provide an ID for and image to be cached!', __FILE__, __LINE__);
+        }
         $id = $this->generateID($id, $format);
         $types = ImageTypes();
 
         // Check if the requested image type is supported by the GD lib.
         // If not, try a callback to the first available image type.
         if (!isset($this->imagetypes[$format]) || !($types & $this->imagetypes[$format])) {
-            foreach ($this->imagetypes as $supported => $bitmask) 
+            foreach ($this->imagetypes as $supported => $bitmask) {
                 if ($types & $bitmask) {
                     new Cache_Error("The build in GD lib does not support the image type $format. Fallback to $supported.", __FILE__, __LINE__);
                 } else {
                     return new Cache_Error("Hmm, is your PHP build with GD support? Can't find any supported types.", __FILE__, __LINE__);
                 }
+            }
         }
 
         $url = $this->cache_url . $this->cache_file_prefix . $id;
@@ -314,34 +314,34 @@ class Cache_Graphics extends Cache
         return array($ffile, $url);
     } // end func cacheImageLink
 
-    
+
     /**
-    * Sets the URL prefix used when rendering HTML Tags. 
-    * 
-    * Make sure that the URL matches the cache directory, 
-    * otherwise you'll get broken links.
-    * 
-    * @param    string
-    * @access   public
-    * @see      setCacheDir()
-    */
+     * Sets the URL prefix used when rendering HTML Tags.
+     *
+     * Make sure that the URL matches the cache directory,
+     * otherwise you'll get broken links.
+     *
+     * @param  string
+     * @access public
+     * @see    setCacheDir()
+     */
     function setCacheURL($cache_url)
     {
         if ($cache_url && '/' != substr($cache_url, 1)) {
             $cache_url .= '/';
         }
         $this->cache_url = $cache_url;
-        
+
     } // end func setCacheURL
 
-    
+
     /**
-    * Sets the directory where to cache generated Images
-    * 
-    * @param    string
-    * @access   public
-    * @see      setCacheURL()
-    */
+     * Sets the directory where to cache generated Images
+     *
+     * @param  string
+     * @access public
+     * @see    setCacheURL()
+     */
     function setCacheDir($cache_dir)
     {
         if ($cache_dir && '/' != substr($cache_dir, 1)) {
@@ -350,13 +350,13 @@ class Cache_Graphics extends Cache
         $this->cache_dir = $cache_dir;
         $this->container->cache_dir = $cache_dir;
     } // end func setCacheDir
-    
-    
+
+
     function generateID($variable, $format = 'png')
     {
-      return md5(serialize($variable)) . '.' . $format;
+        return md5(serialize($variable)) . '.' . $format;
     } // end func generateID
-    
-    
+
+
 } // end class Cache_Graphics
 ?>

--- a/Cache/HTTP/Request.php
+++ b/Cache/HTTP/Request.php
@@ -27,38 +27,38 @@ define('CACHE_HTTP_REQUEST_RETURN_FALSE', 2);
 define('CACHE_HTTP_REQUEST_RETURN_PEAR_ERROR', 3);
 
 /**
-* HTTP_Request Cache
-*
-* The classical example is :
-*
-* You want to get news from another site through RSS remote files. But you
-* don't want to access to to the remote site at every time you display
-* its news on your site. Because, if the remote site is down or slow...
-* So you you need a class which makes a local cache copy of the remote file.
-* Every x hours, the cache is updated. But if the remote site is down, the
-* local cache copy is keeped (you can also get error messages if you want).
-*
-* So you need this class!
-*
-* Cache_HTTP_Request inherits from Cache and use HTTP_Request to access to
-* the remote file.
-*
-* Usage example :
-*
-* <?php
-* require_once('Cache/HTTP_Request.php');
-*
-* $cache = &new Cache_HTTP_Request('http://www.php.net', null, 'file', null, 3600);
-* $cache->sendRequest();
-* $remoteFileBody = $cache->getResponseBody();
-*
-* (...)
-* ?>
-*
-* @author   Fabien MARTY <fabien.marty@free.fr>
-* @version  $Id$
-* @package  Cache
-*/
+ * HTTP_Request Cache
+ *
+ * The classical example is :
+ *
+ * You want to get news from another site through RSS remote files. But you
+ * don't want to access to to the remote site at every time you display
+ * its news on your site. Because, if the remote site is down or slow...
+ * So you you need a class which makes a local cache copy of the remote file.
+ * Every x hours, the cache is updated. But if the remote site is down, the
+ * local cache copy is keeped (you can also get error messages if you want).
+ *
+ * So you need this class!
+ *
+ * Cache_HTTP_Request inherits from Cache and use HTTP_Request to access to
+ * the remote file.
+ *
+ * Usage example :
+ *
+ * <?php
+ * require_once('Cache/HTTP_Request.php');
+ *
+ * $cache = &new Cache_HTTP_Request('http://www.php.net', null, 'file', null, 3600);
+ * $cache->sendRequest();
+ * $remoteFileBody = $cache->getResponseBody();
+ *
+ * (...)
+ * ?>
+ *
+ * @author  Fabien MARTY <fabien.marty@free.fr>
+ * @version $Id$
+ * @package Cache
+ */
 
 class Cache_HTTP_Request extends Cache
 {
@@ -66,72 +66,73 @@ class Cache_HTTP_Request extends Cache
     // --- Private properties ---
 
     /**
-    * Lifetime in seconds (0 endless)
-    *
-    * @var int $_expires
-    */
+     * Lifetime in seconds (0 endless)
+     *
+     * @var int $_expires
+     */
     var $_expires;
 
     /**
-    * HTTP Request
-    *
-    * @var object $_request
-    */
+     * HTTP Request
+     *
+     * @var object $_request
+     */
     var $_request;
 
     /**
-    * Cache id for the classic cache file
-    *
-    * @see sendRequest()
-    * @var string $_id
-    */
+     * Cache id for the classic cache file
+     *
+     * @see sendRequest()
+     * @var string $_id
+     */
     var $_id;
 
     /**
-    * Cache id for the endless cache file
-    *
-    * @see sendRequest()
-    * @var string $_id
-    */
+     * Cache id for the endless cache file
+     *
+     * @see sendRequest()
+     * @var string $_id
+     */
     var $_id2;
 
     /**
-    * Data to use
-    *
-    * @see getReponseBody(), getReponseHeader(), getReponseCode()
-    * @var array $_data
-    */
+     * Data to use
+     *
+     * @see getReponseBody(), getReponseHeader(), getReponseCode()
+     * @var array $_data
+     */
     var $_data ;
 
     // --- Public methods ---
 
     /**
-    * Constructor
-    *
-    * @param $url The url to access
-    * @param $params Associative array of parameters which can be:
-    *                  method     - Method to use, GET, POST etc
-    *                  http       - HTTP Version to use, 1.0 or 1.1
-    *                  user       - Basic Auth username
-    *                  pass       - Basic Auth password
-    *                  proxy_host - Proxy server host
-    *                  proxy_port - Proxy server port
-    *                  proxy_user - Proxy auth username
-    *                  proxy_pass - Proxy auth password
-    * @param string $container Name of container class
-    * @param array $containerOptions Array with container class options
-    * @param int $mode What to do when the remote server is down :
-    *                   CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY or
-    *                   CACHE_HTTP_REQUEST_RETURN_FALSE or
-    *                   CACHE_HTTP_REQUEST_RETURN_PEAR_ERROR
-    * @param int $expires lifetime of the cached data in seconds - 0 for endless
-    * @see Cache, HTTP_Request
-    * @access public
-    */
-    function Cache_HTTP_Request($url, $params = null, $container  = 'file',
-                                $containerOptions = null, $expires = 3600,
-                                $mode = CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY)
-    {
+     * Constructor
+     *
+     * @param $url The url to access
+     * @param $params Associative array of parameters which can be:
+     *                  method     - Method to use, GET, POST etc
+     *                  http       - HTTP Version to use, 1.0 or 1.1
+     *                  user       - Basic Auth username
+     *                  pass       - Basic Auth password
+     *                  proxy_host - Proxy server host
+     *                  proxy_port - Proxy server port
+     *                  proxy_user - Proxy auth username
+     *                  proxy_pass - Proxy auth password
+     * @param string                                               $container        Name of container class
+     * @param array                                                $containerOptions Array with container class options
+     * @param int                                                  $mode             What to do when the remote server is down :
+     *                                                                               CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY or
+     *                                                                               CACHE_HTTP_REQUEST_RETURN_FALSE or
+     *                                                                               CACHE_HTTP_REQUEST_RETURN_PEAR_ERROR
+     *
+     * @param  int                                                  $expires          lifetime of the cached data in seconds - 0 for endless
+     * @see    Cache, HTTP_Request
+     * @access public
+     */
+    function __construct($url, $params = null, $container  = 'file',
+        $containerOptions = null, $expires = 3600,
+        $mode = CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY
+    ) {
         if (!isset($params)) {
             $params = array();
         }
@@ -143,7 +144,7 @@ class Cache_HTTP_Request extends Cache
             );
         }
         $this->Cache($container, $containerOptions);
-        $this->_request = &new HTTP_Request($url, $params);
+        $this->_request = new HTTP_Request($url, $params);
         $this->_id = md5($url.serialize($params));
         $this->_id2 = md5($this->_id); // we need two keys
         $this->_mode = $mode;
@@ -151,46 +152,46 @@ class Cache_HTTP_Request extends Cache
     }
 
     /**
-    * Deconstructor
-    *
-    * @access public
-    */
+     * Deconstructor
+     *
+     * @access public
+     */
     function _Cache_HTTP_Request()
     {
         $this->_Cache();
     }
 
     /**
-    * Get and return the response body (null if no data available)
-    *
-    * @see sendRequest()
-    * @return mixed response body
-    * @access public
-    */
+     * Get and return the response body (null if no data available)
+     *
+     * @see    sendRequest()
+     * @return mixed response body
+     * @access public
+     */
     function getResponseBody()
     {
         return $this->_data['body'];
     }
 
     /**
-    * Get and return the response code (null if no data available)
-    *
-    * @see sendRequest()
-    * @return mixed response code
-    * @access public
-    */
+     * Get and return the response code (null if no data available)
+     *
+     * @see    sendRequest()
+     * @return mixed response code
+     * @access public
+     */
     function getResponseCode()
     {
         return $this->_data['code'];
     }
 
     /**
-    * Get and return the response header (null if no data available)
-    *
-    * @see sendRequest()
-    * @return mixed response header
-    * @access public
-    */
+     * Get and return the response header (null if no data available)
+     *
+     * @see    sendRequest()
+     * @return mixed response header
+     * @access public
+     */
     function getResponseHeader()
     {
         return $this->_data['header'];
@@ -198,40 +199,40 @@ class Cache_HTTP_Request extends Cache
 
 
     /**
-    * Set a new mode when the server is down
-    *
-    * @param int $newMode What to do when the remote server is down :
-    *                      CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY or
-    *                      CACHE_HTTP_REQUEST_RETURN_FALSE or
-    *                      CACHE_HTTP_REQUEST_RETURN_PEAR_ERROR
-    * @access public
-    */
+     * Set a new mode when the server is down
+     *
+     * @param  int $newMode What to do when the remote server is down :
+     *                      CACHE_HTTP_REQUEST_KEEP_LOCAL_COPY or
+     *                      CACHE_HTTP_REQUEST_RETURN_FALSE or
+     *                      CACHE_HTTP_REQUEST_RETURN_PEAR_ERROR
+     * @access public
+     */
     function setMode($newMode)
     {
         $this->_mode = $newMode;
     }
 
     /**
-    * Send the HTTP request or use the cache system
-    *
-    * If there is a cache file for this HTTP request, the request is not re-sent.
-    * Cached response is used. Yet, if the cache is expired, the HTTP request
-    * is re-sent. Then, if the remote server is down, this method will return :
-    * (depending on the selected mode)
-    * - false or
-    * - a PEAR_Error or (better)
-    * - true and the local copy of the latest valid response will be used.
-    *
-    * (technical)
-    * For the last choice, there is a technical tips.
-    * Indeed, there are two cache files. The first one (id key) is a classical one
-    * with the given lifetime. But it can be removed by automatic garbage collection
-    * for example. So to be able to use the latest valid response (when the remote
-    * server is dead), we make a second cache file with no lifetime (id2 key).
-    *
-    * @return mixed true or false or a PEAR_ERROR
-    * @access public
-    */
+     * Send the HTTP request or use the cache system
+     *
+     * If there is a cache file for this HTTP request, the request is not re-sent.
+     * Cached response is used. Yet, if the cache is expired, the HTTP request
+     * is re-sent. Then, if the remote server is down, this method will return :
+     * (depending on the selected mode)
+     * - false or
+     * - a PEAR_Error or (better)
+     * - true and the local copy of the latest valid response will be used.
+     *
+     * (technical)
+     * For the last choice, there is a technical tips.
+     * Indeed, there are two cache files. The first one (id key) is a classical one
+     * with the given lifetime. But it can be removed by automatic garbage collection
+     * for example. So to be able to use the latest valid response (when the remote
+     * server is dead), we make a second cache file with no lifetime (id2 key).
+     *
+     * @return mixed true or false or a PEAR_ERROR
+     * @access public
+     */
     function sendRequest()
     {
         if ($data = $this->get($this->_id, CACHE_HTTP_REQUEST_GROUP_NAME)) {
@@ -275,12 +276,12 @@ class Cache_HTTP_Request extends Cache
     // --- Private Methods ---
 
     /**
-    * Send HTTP request and get the response
-    *
-    * @return boolean success or not ?
-    * @see HTTP_Request
-    * @access private
-    */
+     * Send HTTP request and get the response
+     *
+     * @return boolean success or not ?
+     * @see    HTTP_Request
+     * @access private
+     */
     function _sendRequestAndGetResponse()
     {
         $this->_request->sendRequest();

--- a/Cache/Output.php
+++ b/Cache/Output.php
@@ -22,114 +22,114 @@
 require_once 'Cache.php';
 
 /**
-* Class to cache the output of a script using the output buffering functions
-*
-* Simple output cache. Some pages require lots of time to compute. Caching the
-* output can increase the overall speed dramatically, especially if you use
-* a Shared Memory storage container.
-*
-* As you can see in the example the usage is extemely simple. To cache a script
-* simple put some few lines of code in front of your script and some at the end.
-* A preferrable place for this are the auto_prepend and auto_append files (=> php.ini).
-*
-* Usage example:
-*
-*  // place this somewhere in a central config file
-*  define(CACHE_STORAGE_CLASS, 'file');
-*  // file storage needs a dir to put the cache files
-*  define(CACHE_DIR, '/var/tmp/');
-*
-*  // get a cache object
-*  $cache = new Cache_Output(CACHE_STORAGE_CLASS, array('cache_dir' => CACHE_DIR));
-*
-*  // compute the unique handle.
-*  // if your script depends on Cookie and HTTP Post data as well
-*  // you should use:
-*  // $cache_handle = array(
-*  //                       'file' => $REQUEST_URI,
-*  //                       'post' => $HTTP_POST_VARS,
-*  //                       'cookie'  => $HTTP_COOKIE_VARS
-*  //                    );
-*  // But be warned, using all GET or POST Variables as a seed
-*  // can be used for a DOS attack. Calling http://www.example.com/example.php?whatever
-*  // where whatever is a random text might be used to flood your cache.
-*  $cache_handle = $cache->generateID($REQUEST_URI);
-*
-*  // now the magic happens: if cached call die()
-*  // to end the time consumptiong script script execution and use the cached value!
-*  if ($content = $cache->start($cache_handle)) {
-*     print $content;
-*     print '<p>Cache hit</p>';
-*     die();
-*  }
-*
-*  // time consumption script goes here.
-*
-*  // store the output of the cache into the cache and print the output.
-*  print $cache->end();
-*  print "<p>Cache miss, stored using the ID '$id'.</p>";
-*
-*  If you do not want to cache a whole page - no problem:
-*
-*  if (!($content = $cache->start($cache_handle))) {
-*     // do the computation here
-*     print $cache->end()
-*  } else {
-*     print $content;
-*  }
-*
-*  If you need an example script check the (auto_)prepend and (auto_)append
-*  files of my homepage:
-*
-*    http://www.ulf-wendel.de/php/show_source.php?file=prepend
-*    http://www.ulf-wendel.de/php/show_source.php?file=append
-*
-*  Don't know how to use it or you need profiling informations?`
-*  Ask Christian he was patient with me and he'll be so with your questions ;).
-*
-*  Have fun!
-*
-* @authors  Ulf Wendel <ulf.wendel@phpdoc.de>
-* @version  $ID: $
-* @package  Cache
-* @access   public
-*/
+ * Class to cache the output of a script using the output buffering functions
+ *
+ * Simple output cache. Some pages require lots of time to compute. Caching the
+ * output can increase the overall speed dramatically, especially if you use
+ * a Shared Memory storage container.
+ *
+ * As you can see in the example the usage is extemely simple. To cache a script
+ * simple put some few lines of code in front of your script and some at the end.
+ * A preferrable place for this are the auto_prepend and auto_append files (=> php.ini).
+ *
+ * Usage example:
+ *
+ *  // place this somewhere in a central config file
+ *  define(CACHE_STORAGE_CLASS, 'file');
+ *  // file storage needs a dir to put the cache files
+ *  define(CACHE_DIR, '/var/tmp/');
+ *
+ *  // get a cache object
+ *  $cache = new Cache_Output(CACHE_STORAGE_CLASS, array('cache_dir' => CACHE_DIR));
+ *
+ *  // compute the unique handle.
+ *  // if your script depends on Cookie and HTTP Post data as well
+ *  // you should use:
+ *  // $cache_handle = array(
+ *  //                       'file' => $REQUEST_URI,
+ *  //                       'post' => $HTTP_POST_VARS,
+ *  //                       'cookie'  => $HTTP_COOKIE_VARS
+ *  //                    );
+ *  // But be warned, using all GET or POST Variables as a seed
+ *  // can be used for a DOS attack. Calling http://www.example.com/example.php?whatever
+ *  // where whatever is a random text might be used to flood your cache.
+ *  $cache_handle = $cache->generateID($REQUEST_URI);
+ *
+ *  // now the magic happens: if cached call die()
+ *  // to end the time consumptiong script script execution and use the cached value!
+ *  if ($content = $cache->start($cache_handle)) {
+ *     print $content;
+ *     print '<p>Cache hit</p>';
+ *     die();
+ *  }
+ *
+ *  // time consumption script goes here.
+ *
+ *  // store the output of the cache into the cache and print the output.
+ *  print $cache->end();
+ *  print "<p>Cache miss, stored using the ID '$id'.</p>";
+ *
+ *  If you do not want to cache a whole page - no problem:
+ *
+ *  if (!($content = $cache->start($cache_handle))) {
+ *     // do the computation here
+ *     print $cache->end()
+ *  } else {
+ *     print $content;
+ *  }
+ *
+ *  If you need an example script check the (auto_)prepend and (auto_)append
+ *  files of my homepage:
+ *
+ *    http://www.ulf-wendel.de/php/show_source.php?file=prepend
+ *    http://www.ulf-wendel.de/php/show_source.php?file=append
+ *
+ *  Don't know how to use it or you need profiling informations?`
+ *  Ask Christian he was patient with me and he'll be so with your questions ;).
+ *
+ *  Have fun!
+ *
+ * @authors Ulf Wendel <ulf.wendel@phpdoc.de>
+ * @version $ID: $
+ * @package Cache
+ * @access  public
+ */
 class Cache_Output extends Cache
 {
 
     /**
-    * ID passed to start()
-    *
-    * @var  string
-    * @see  start(), end()
-    */
+     * ID passed to start()
+     *
+     * @var string
+     * @see start(), end()
+     */
     var $output_id = '';
 
     /**
-    * Group passed to start()
-    *
-    * @var  string
-    * @see  start(), end()
-    */
+     * Group passed to start()
+     *
+     * @var string
+     * @see start(), end()
+     */
     var $output_group = '';
 
     /**
-    * PEAR-Deconstructor
-    * Call deconstructor of parent
-    */
+     * PEAR-Deconstructor
+     * Call deconstructor of parent
+     */
     function _Cache_Output()
     {
         $this->_Cache();
     }
 
     /**
-    * starts the output buffering and returns an empty string or returns the cached output from the cache.
-    *
-    * @param    string  dataset ID
-    * @param    string  cache group
-    * @return   string
-    * @access   public
-    */
+     * starts the output buffering and returns an empty string or returns the cached output from the cache.
+     *
+     * @param  string  dataset ID
+     * @param  string  cache group
+     * @return string
+     * @access public
+     */
     function start($id, $group = 'default')
     {
         if (!$this->caching) {
@@ -173,22 +173,22 @@ class Cache_Output extends Cache
     } // end func end()
 
     /**
-    * Stores the content of the output buffer into the cache and prints the content.
-    *
-    * @brother  end()
-    */
+     * Stores the content of the output buffer into the cache and prints the content.
+     *
+     * @brother end()
+     */
     function endPrint($expire = 0, $userdata = '')
     {
         $this->printContent($this->end($expire, $userdata));
     } // end func endPrint
 
     /**
-    * Sends the data to the user.
-    * This is for compatibility with OutputCompression
-    * 
-    * @param    string
-    * @access   public
-    */    
+     * Sends the data to the user.
+     * This is for compatibility with OutputCompression
+     *
+     * @param  string
+     * @access public
+     */
     function printContent($content = '')
     {
         if ($content == '') {
@@ -197,16 +197,16 @@ class Cache_Output extends Cache
         print $content;
     }
     /**
-    * Returns the content of the output buffer but does not store it into the cache.
-    *
-    * Use this method if the content of your script is markup (XML)
-    * that has to be parsed/converted (XSLT) before you can output
-    * and store it into the cache using save().
-    *
-    * @return   string
-    * @access   public
-    * @see      endPrint(), end()
-    */
+     * Returns the content of the output buffer but does not store it into the cache.
+     *
+     * Use this method if the content of your script is markup (XML)
+     * that has to be parsed/converted (XSLT) before you can output
+     * and store it into the cache using save().
+     *
+     * @return string
+     * @access public
+     * @see    endPrint(), end()
+     */
     function endGet()
     {
         $content = ob_get_contents();

--- a/Cache/OutputCompression.php
+++ b/Cache/OutputCompression.php
@@ -19,88 +19,88 @@
 require_once 'Cache/Output.php';
 
 /**
-* Cache using Output Buffering and contnet (gz) compression.
-** Usage example:
-*
-*  // place this somewhere in a central config file
-*  define(CACHE_STORAGE_CLASS, 'file');
-*  // file storage needs a dir to put the cache files
-*  define(CACHE_DIR, '/var/tmp/');
-*
-*  // get a cache object
-*  $cache = new Cache_Output(CACHE_STORAGE_CLASS, array('cache_dir' => CACHE_DIR));
-*
-*  if (!($content = $cache->start($cache->generateID($REQUEST_URI)))) {
-*    print "hello world";
-*    $cache->endPrint(+1000);
-*  }
-*  else {
-*    $cache->printContent();
-*  }
-*
-*   OR
-*
-*  if (($content = $cache->start($cache->generateID($REQUEST_URI)))) {
-*    $cache->printContent();
-*    die();
-*  }
-*    print "hello world";
-*    $cache->endPrint(+1000);
-*
-*
-* Based upon a case study from Christian Stocker and inspired by jpcache.
-*
-* @version  $Id$
-* @author   Ulf Wendel <ulf.wendel@phpdoc.de>, Christian Stocker <chregu@phant.ch>
-* @access   public
-* @package  Cache
-*/
+ * Cache using Output Buffering and contnet (gz) compression.
+ * * Usage example:
+ *
+ *  // place this somewhere in a central config file
+ *  define(CACHE_STORAGE_CLASS, 'file');
+ *  // file storage needs a dir to put the cache files
+ *  define(CACHE_DIR, '/var/tmp/');
+ *
+ *  // get a cache object
+ *  $cache = new Cache_Output(CACHE_STORAGE_CLASS, array('cache_dir' => CACHE_DIR));
+ *
+ *  if (!($content = $cache->start($cache->generateID($REQUEST_URI)))) {
+ *    print "hello world";
+ *    $cache->endPrint(+1000);
+ *  }
+ *  else {
+ *    $cache->printContent();
+ *  }
+ *
+ *   OR
+ *
+ *  if (($content = $cache->start($cache->generateID($REQUEST_URI)))) {
+ *    $cache->printContent();
+ *    die();
+ *  }
+ *    print "hello world";
+ *    $cache->endPrint(+1000);
+ *
+ *
+ * Based upon a case study from Christian Stocker and inspired by jpcache.
+ *
+ * @version $Id$
+ * @author  Ulf Wendel <ulf.wendel@phpdoc.de>, Christian Stocker <chregu@phant.ch>
+ * @access  public
+ * @package Cache
+ */
 class Cache_OutputCompression extends Cache_Output
 {
-    
+
     /**
-    * Encoding, what the user (its browser) of your website accepts
-    * 
-    * "auto" stands for test using $_SERVER['HTTP_ACCEPT_ENCODING']($HTTP_ACCEPT_ENCODING).
-    *
-    * @var  string
-    * @see  Cache_OutputCompression(), setEncoding()
-    */
+     * Encoding, what the user (its browser) of your website accepts
+     *
+     * "auto" stands for test using $_SERVER['HTTP_ACCEPT_ENCODING']($HTTP_ACCEPT_ENCODING).
+     *
+     * @var string
+     * @see Cache_OutputCompression(), setEncoding()
+     */
     var $encoding = 'auto';
- 
-    
+
+
     /**
-    * Method used for compression
-    *
-    * @var  string
-    * @see  isCompressed()
-    */ 
+     * Method used for compression
+     *
+     * @var string
+     * @see isCompressed()
+     */
     var $compression = '';
 
-    
+
     /**
-    * Sets the storage details and the content encoding used (if not autodetection)
-    * 
-    * @param    string  Name of container class
-    * @param    array   Array with container class options
-    * @param    string  content encoding mode - auto => test which encoding the user accepts
-    */    
-    function Cache_OutputCompression($container, $container_options = '', $encoding = 'auto')
+     * Sets the storage details and the content encoding used (if not autodetection)
+     *
+     * @param string  Name of container class
+     * @param array   Array with container class options
+     * @param string  content encoding mode - auto => test which encoding the user accepts
+     */
+    function __construct($container, $container_options = '', $encoding = 'auto')
     {
         $this->setEncoding($encoding);
         $this->Cache($container, $container_options);
-        
+
     } // end constructor
 
-    
+
     /**
-    * Call parent deconstructor.
-    */
+     * Call parent deconstructor.
+     */
     function _Cache_OutputCompression()
     {
         $this->_Cache();
     } // end deconstructor
-    
+
 
     function generateID($variable)
     {
@@ -108,11 +108,11 @@ class Cache_OutputCompression extends Cache_Output
         return md5(serialize($variable) . serialize($this->compression));
     } // end generateID
 
-    
+
     function get($id, $group)
     {
         $this->content = '';
-        
+
         if (!$this->caching) {
             return '';
         }
@@ -122,14 +122,14 @@ class Cache_OutputCompression extends Cache_Output
         }
         return $this->content;
     } // end func get
-    
-    
+
+
     /**
-    * Stops the output buffering, saves it to the cache and returns the _compressed_ content. 
-    *
-    * If you need the uncompressed content for further procession before
-    * it's saved in the cache use endGet(). endGet() does _not compress_.
-    */    
+     * Stops the output buffering, saves it to the cache and returns the _compressed_ content.
+     *
+     * If you need the uncompressed content for further procession before
+     * it's saved in the cache use endGet(). endGet() does _not compress_.
+     */
     function end($expire = 0, $userdata = '')
     {
         $content = ob_get_contents();
@@ -138,23 +138,22 @@ class Cache_OutputCompression extends Cache_Output
         // store in the cache
         if ($this->caching) {
             $this->extSave($this->output_id, $content, $userdata, $expire, $this->output_group);
-            return $this->content;                
+            return $this->content;
         }
-            
-        return $content;        
+
+        return $content;
     } // end func end()
-    
-    
+
+
     function endPrint($expire = 0, $userdata = '')
     {
         $this->printContent($this->end($expire, $userdata));
     } // end func endPrint
 
-    
+
     /**
-    * Saves the given data to the cache.
-    * 
-    */   
+     * Saves the given data to the cache.
+     */
     function extSave($id, $cachedata, $userdata, $expires = 0, $group = 'default')
     {
         if (!$this->caching) {
@@ -162,7 +161,7 @@ class Cache_OutputCompression extends Cache_Output
         }
 
         if ($this->compression) {
-            $len = strlen($cachedata);            
+            $len = strlen($cachedata);
             $crc = crc32($cachedata);
             $cachedata = gzcompress($cachedata, 9);
             $this->content = substr($cachedata, 0, strlen($cachedata) - 4) . pack('V', $crc) . pack('V', $len);
@@ -171,13 +170,13 @@ class Cache_OutputCompression extends Cache_Output
         }
         return $this->container->save($id, $this->content, $expires, $group, $userdata);
     } // end func extSave
-    
+
     /**
-    * Sends the compressed data to the user.
-    * 
-    * @param    string
-    * @access   public
-    */    
+     * Sends the compressed data to the user.
+     *
+     * @param  string
+     * @access public
+     */
     function printContent($content = '')
     {
         $server = &$this->_importGlobalVariable("server");
@@ -199,47 +198,47 @@ class Cache_OutputCompression extends Cache_Output
                 header('Vary: Accept-Encoding');
                 print "\x1f\x8b\x08\x00\x00\x00\x00\x00";
             }
-        
+
         }
-        
+
         die($content);
     } // end func printContent
-    
-    
+
+
     /**
-    * Returns the encoding method of the current dataset. 
-    *
-    * @access   public
-    * @return   string  Empty string (which evaluates to false) means no compression
-    */
+     * Returns the encoding method of the current dataset.
+     *
+     * @access public
+     * @return string  Empty string (which evaluates to false) means no compression
+     */
     function isCompressed()
     {
         return $this->compression;
     } // end func isCompressed
 
     /**
-    * Sets the encoding to be used.
-    * 
-    * @param    string  "auto" means autodetect for every client
-    * @access   public
-    * @see      $encoding
-    */
+     * Sets the encoding to be used.
+     *
+     * @param  string  "auto" means autodetect for every client
+     * @access public
+     * @see    $encoding
+     */
     function setEncoding($encoding = 'auto')
     {
         $this->encoding = $encoding;
     } // end func setEncoding
-    
-    
+
+
     /**
-    * Returns the encoding to be used for the data transmission to the client.
-    *
-    * @see      setEncoding()
-    */    
+     * Returns the encoding to be used for the data transmission to the client.
+     *
+     * @see setEncoding()
+     */
     function getEncoding()
     {
         $server = &$this->_importGlobalVariable("server");
 
-        // encoding set by user    
+        // encoding set by user
         if ('auto' != $this->encoding) {
             return $this->encoding;
         }
@@ -252,7 +251,7 @@ class Cache_OutputCompression extends Cache_Output
         }
         // no compression
         return '';
-        
+
     } // end func getEncoding
 
     // {{{ _importGlobalVariable()
@@ -261,47 +260,47 @@ class Cache_OutputCompression extends Cache_Output
      * Import variables from special namespaces.
      *
      * @access private
-     * @param string Type of variable (server, session, post)
+     * @param  string Type of variable (server, session, post)
      * @return array
      */
-    function &_importGlobalVariable($variable) 
+    function &_importGlobalVariable($variable)
     {
-      
+
         $var = null;
 
         switch (strtolower($variable)) {
 
-            case 'server':
-                if (isset($_SERVER)) {
-                    $var = &$_SERVER;
-                } else {
-                    $var = &$GLOBALS['HTTP_SERVER_VARS'];
-                }
-                break;
+        case 'server':
+            if (isset($_SERVER)) {
+                $var = &$_SERVER;
+            } else {
+                $var = &$GLOBALS['HTTP_SERVER_VARS'];
+            }
+            break;
 
-            case 'session':
-                if (isset($_SESSION)) {
-                    $var = &$_SESSION;
-                } else {
-                    $var = &$GLOBALS['HTTP_SESSION_VARS'];
-                }
-                break;
+        case 'session':
+            if (isset($_SESSION)) {
+                $var = &$_SESSION;
+            } else {
+                $var = &$GLOBALS['HTTP_SESSION_VARS'];
+            }
+            break;
 
-            case 'post':
-                if (isset($_POST)) {
-                    $var = &$_POST;
-                } else {
-                    $var = &$GLOBALS['HTTP_POST_VARS'];
-                }
-                break;
+        case 'post':
+            if (isset($_POST)) {
+                $var = &$_POST;
+            } else {
+                $var = &$GLOBALS['HTTP_POST_VARS'];
+            }
+            break;
 
-            default:
-                break;
+        default:
+            break;
 
         }
 
         return $var;
-    } 
+    }
 
     // }}
 } // end class OutputCompression


### PR DESCRIPTION
Two main reasons for this:
1) Old-style constructors are deprecated (where they are named for/after the class).
2) PEAR packages that don't adhere to PEAR Coding Standards (or an amalgam of PEAR & PSR* Standards)...oh $DEITY no!